### PR TITLE
Remove defaults time

### DIFF
--- a/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveAPI.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveAPI.approved.txt
@@ -10,9 +10,8 @@ namespace NServiceBus
     public class MetricsOptions
     {
         public MetricsOptions() { }
-        public void EnableLogTracing(System.Nullable<System.TimeSpan> interval = null, System.Nullable<NServiceBus.Logging.LogLevel> logLevel = null) { }
-        public void EnableMetricTracing(System.Nullable<System.TimeSpan> interval = null) { }
-        public void SendMetricDataToServiceControl(string serviceControlMetricsAddress, System.Nullable<System.TimeSpan> interval = null) { }
-        public void SetDefaultInterval(System.TimeSpan interval) { }
+        public void EnableLogTracing(System.TimeSpan interval, NServiceBus.Logging.LogLevel logLevel = 0) { }
+        public void EnableMetricTracing(System.TimeSpan interval) { }
+        public void SendMetricDataToServiceControl(string serviceControlMetricsAddress, System.TimeSpan interval) { }
     }
 }

--- a/src/NServiceBus.Metrics/MetricsOptions.cs
+++ b/src/NServiceBus.Metrics/MetricsOptions.cs
@@ -18,15 +18,14 @@
         /// </summary>
         /// <param name="serviceControlMetricsAddress">The transport address of the ServiceControl instance</param>
         /// <param name="interval">How frequently metric data is sent to ServiceControl</param>
-        /// <remarks>If no interval is specified then the Default Interval is used</remarks>
-        public void SendMetricDataToServiceControl(string serviceControlMetricsAddress, TimeSpan? interval = null)
+        public void SendMetricDataToServiceControl(string serviceControlMetricsAddress, TimeSpan interval)
         {
             Guard.AgainstNullAndEmpty(nameof(serviceControlMetricsAddress), serviceControlMetricsAddress);
             Guard.AgainstNegativeAndZero(nameof(interval), interval);
 
             reportInstallers.Add((builder, config) => config.WithReport(
                 new NServiceBusMetricReport(builder.Build<IDispatchMessages>(), serviceControlMetricsAddress),
-                interval ?? defaultInterval
+                interval
             ));
         }
 
@@ -34,14 +33,13 @@
         /// Enables sending metric data to the trace log
         /// </summary>
         /// <param name="interval">How often metric data is sent to the trace log</param>
-        /// <remarks>If no interval is specified then the Default Interval is used</remarks>
-        public void EnableMetricTracing(TimeSpan? interval = null)
+        public void EnableMetricTracing(TimeSpan interval)
         {
             Guard.AgainstNegativeAndZero(nameof(interval), interval);
 
             reportInstallers.Add((builder, config) => config.WithReport(
                 new TraceReport(),
-                interval ?? defaultInterval
+                interval
             ));
         }
 
@@ -50,29 +48,14 @@
         /// </summary>
         /// <param name="interval">How often metric data is sent to the log</param>
         /// <param name="logLevel">Level at which log entries should be written. Default is DEBUG.</param>
-        /// <remarks>
-        /// If no interval is specified then the Default Interval is used.
-        /// Metrics data will be logged at the INFO log level
-        /// </remarks>
-        public void EnableLogTracing(TimeSpan? interval = null, LogLevel? logLevel = null)
+        public void EnableLogTracing(TimeSpan interval, LogLevel logLevel = LogLevel.Debug)
         {
             Guard.AgainstNegativeAndZero(nameof(interval), interval);
 
             reportInstallers.Add((builder, config) => config.WithReport(
-                new MetricsLogReport(logLevel ?? LogLevel.Debug),
-                interval ?? defaultInterval
+                new MetricsLogReport(logLevel),
+                interval
             ));
-        }
-
-        /// <summary>
-        /// Sets the default interval for reporting metric data
-        /// </summary>
-        /// <param name="interval">The new default interval</param>
-        public void SetDefaultInterval(TimeSpan interval)
-        {
-            Guard.AgainstNegativeAndZero(nameof(interval), interval);
-
-            defaultInterval = interval;
         }
 
         internal void SetUpReports(MetricsConfig config, IBuilder builder)
@@ -80,7 +63,6 @@
             config.WithReporting(reportsConfig => reportInstallers.ForEach(installer => installer(builder, reportsConfig)));
         }
 
-        TimeSpan defaultInterval = TimeSpan.FromSeconds(30);
         List<Action<IBuilder, MetricsReports>> reportInstallers = new List<Action<IBuilder, MetricsReports>>();
     }
 }


### PR DESCRIPTION
Looking at the different reporters, I don't think there is any value in having a default time for any of them. Instead, let's be explicit and require customers to set a value. That way, they'll need to be aware of the decision they are making and the effect it might be having. If we find that having a default makes sense in the future we can always reintroduce it. 