### PR TITLE
Allow EnableMetrics on settings holder 

### DIFF
--- a/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveAPI.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveAPI.approved.txt
@@ -5,6 +5,7 @@ namespace NServiceBus
 {
     public class static MetricsConfigurationExtensions
     {
+        public static NServiceBus.MetricsOptions EnableMetrics(this NServiceBus.Settings.SettingsHolder settings) { }
         public static NServiceBus.MetricsOptions EnableMetrics(this NServiceBus.EndpointConfiguration endpointConfiguration) { }
     }
     public class MetricsOptions

--- a/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus
 {
     using Configuration.AdvanceExtensibility;
+    using Features;
+    using Settings;
 
     /// <summary>
     /// Extends Endpoint Configuration to provide Metric options
@@ -8,17 +10,27 @@
     public static class MetricsConfigurationExtensions
     {
         /// <summary>
-        /// Enables the Metrics feature
+        /// Enables the Metrics feature.
         /// </summary>
-        /// <param name="endpointConfiguration">The endpoint configuration to enable the metrics feature on</param>
-        /// <returns>An object containing configuration options for the Metrics feature</returns>
+        /// <param name="settings">The settings to enable the metrics feature on.</param>
+        /// <returns>An object containing configuration options for the Metrics feature.</returns>
+        public static MetricsOptions EnableMetrics(this SettingsHolder settings)
+        {
+            var options = settings.GetOrCreate<MetricsOptions>();
+            settings.Set(typeof(MetricsFeature).FullName, FeatureState.Enabled);
+            return options;
+        }
+
+        /// <summary>
+        /// Enables the Metrics feature.
+        /// </summary>
+        /// <param name="endpointConfiguration">The endpoint configuration to enable the metrics feature on.</param>
+        /// <returns>An object containing configuration options for the Metrics feature.</returns>
         public static MetricsOptions EnableMetrics(this EndpointConfiguration endpointConfiguration)
         {
             Guard.AgainstNull(nameof(endpointConfiguration), endpointConfiguration);
 
-            var options = endpointConfiguration.GetSettings().GetOrCreate<MetricsOptions>();
-            endpointConfiguration.EnableFeature<MetricsFeature>();
-            return options;
+            return EnableMetrics(endpointConfiguration.GetSettings());
         }
     }
 }


### PR DESCRIPTION
so that performance counter feature can active the metrics reporting

Technically it would be possible to do the following in the performance counter

        public static PerformanceCountersSettings EnableWindowsPerformanceCounters(this EndpointConfiguration endpointConfiguration)
        {
            endpointConfiguration.EnableMetrics().CustomReporter(payload => { });
            ...
        }

but it feels super ugly since then everything is essentially almost in a static context since it would be hard to bootstrap infrastructure for it. This extension methods allows the following

```
    class PerformanceCountersFeature : Feature
    {
        MetricsOptions options;

        public PerformanceCountersFeature()
        {
            Defaults(s =>
            {
                options= s.EnableMetrics();
            });
        }

        protected override void Setup(FeatureConfigurationContext context)
        {
            // access options here
        }
    }
```

Thoughts @mikeminutillo @SzymonPobiega @WojcikMike 