### PR TITLE
NServiceBusMetricReport sends out originating machine, host id and originating endpoint

### DIFF
--- a/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_reporting_to_custom_function.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_reporting_to_custom_function.cs
@@ -3,14 +3,13 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_reporting_to_custom_function : NServiceBusAcceptanceTest
     {
-        static Guid HostId = Guid.NewGuid();
-
         [Test]
         public async Task Should_call_defined_func()
         {
@@ -21,7 +20,7 @@
                 .ConfigureAwait(false);
 
             Assert.IsNotNull(context.Data);
-            Assert.That(context.Data, Contains.Substring(HostId.ToString()));
+            Assert.That(context.Data, Contains.Substring($"{Conventions.EndpointNamingConvention(typeof(Reporter))}"));
         }
 
         class Context : ScenarioContext
@@ -37,7 +36,6 @@
                 {
                     var context = (Context)r.ScenarioContext;
 
-                    c.UniquelyIdentifyRunningInstance().UsingCustomIdentifier(HostId);
                     c.EnableMetrics().EnableCustomReport(payload =>
                     {
                         context.Data = payload;

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -16,8 +16,8 @@ class MetricsFeature : Feature
         var settings = context.Settings;
         var metricsOptions = settings.Get<MetricsOptions>();
 
-        var hostId = settings.Get<Guid>("NServiceBus.HostInformation.HostId");
-        MetricsContext metricsContext = new DefaultMetricsContext($"{settings.EndpointName()}@{hostId}");
+        // the context is used as originating endpoint in the headers
+        MetricsContext metricsContext = new DefaultMetricsContext($"{settings.EndpointName()}");
 
         ConfigureMetrics(context, metricsContext);
 

--- a/src/NServiceBus.Metrics/MetricsOptions.cs
+++ b/src/NServiceBus.Metrics/MetricsOptions.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using global::Metrics;
     using global::Metrics.Reports;
+    using Hosting;
     using Logging;
     using ObjectBuilder;
     using Transport;
@@ -26,7 +27,7 @@
             Guard.AgainstNegativeAndZero(nameof(interval), interval);
 
             reportInstallers.Add((builder, config) => config.WithReport(
-                new NServiceBusMetricReport(builder.Build<IDispatchMessages>(), serviceControlMetricsAddress),
+                new NServiceBusMetricReport(builder.Build<IDispatchMessages>(), serviceControlMetricsAddress, builder.Build<HostInformation>()),
                 interval
             ));
         }


### PR DESCRIPTION
Talked to @mikeminutillo today about https://github.com/Particular/LaunchWave.DevOpsAdvancedMonitoring/issues/50#issuecomment-292947394

We said probably the most future proof way for us is to make the context represent the endpoint name only and ship the additional information on the headers.

Another option would have been (or could even be combined with this approach) to add the host id etc. to the environment entry in the metrics payload. But I'd say topic of another PR?

@SzymonPobiega @mikeminutillo thoughts?