### PR TITLE
Expose meters definition

### DIFF
--- a/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveAPI.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveAPI.approved.txt
@@ -1,6 +1,13 @@
 ﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Metrics.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(true)]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.5.2", FrameworkDisplayName=".NET Framework 4.5.2")]
+namespace NServiceBus.Metrics
+{
+    public class static AllMetrics
+    {
+        public static void Define(System.IO.TextWriter writer) { }
+    }
+}
 namespace NServiceBus
 {
     public class static MetricsConfigurationExtensions

--- a/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveMetrics.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveMetrics.approved.txt
@@ -1,0 +1,87 @@
+﻿{
+  "Version":"2",
+  "Timestamp":"1970-01-01T00:00:00.0000",
+  "Meters":[{
+      "Name":"# of message failures / sec",
+      "Count":0,
+      "MeanRate":0.00,
+      "OneMinuteRate":0.00,
+      "FiveMinuteRate":0.00,
+      "FifteenMinuteRate":0.00,
+      "Unit":"Messages",
+      "RateUnit":"s"
+    },{
+      "Name":"# of messages pulled from the input queue / sec",
+      "Count":0,
+      "MeanRate":0.00,
+      "OneMinuteRate":0.00,
+      "FiveMinuteRate":0.00,
+      "FifteenMinuteRate":0.00,
+      "Unit":"Messages",
+      "RateUnit":"s"
+    },{
+      "Name":"# of messages successfully processed / sec",
+      "Count":0,
+      "MeanRate":0.00,
+      "OneMinuteRate":0.00,
+      "FiveMinuteRate":0.00,
+      "FifteenMinuteRate":0.00,
+      "Unit":"Messages",
+      "RateUnit":"s"
+    }],
+  "Timers":[{
+      "Name":"Critical Time",
+      "Count":0,
+      "ActiveSessions":0,
+      "TotalTime":0,
+      "Rate":{
+          "MeanRate":0.00,
+          "OneMinuteRate":0.00,
+          "FiveMinuteRate":0.00,
+          "FifteenMinuteRate":0.00
+        },
+      "Histogram":{
+          "LastValue":0.00,
+          "Min":0.00,
+          "Mean":0.00,
+          "StdDev":0.00,
+          "Median":0.00,
+          "Percentile75":0.00,
+          "Percentile95":0.00,
+          "Percentile98":0.00,
+          "Percentile99":0.00,
+          "Percentile999":0.00,
+          "SampleSize":0
+        },
+      "Unit":"Messages",
+      "RateUnit":"s",
+      "DurationUnit":"ms"
+    },{
+      "Name":"Processing Time",
+      "Count":0,
+      "ActiveSessions":0,
+      "TotalTime":0,
+      "Rate":{
+          "MeanRate":0.00,
+          "OneMinuteRate":0.00,
+          "FiveMinuteRate":0.00,
+          "FifteenMinuteRate":0.00
+        },
+      "Histogram":{
+          "LastValue":0.00,
+          "Min":0.00,
+          "Mean":0.00,
+          "StdDev":0.00,
+          "Median":0.00,
+          "Percentile75":0.00,
+          "Percentile95":0.00,
+          "Percentile98":0.00,
+          "Percentile99":0.00,
+          "Percentile999":0.00,
+          "SampleSize":0
+        },
+      "Unit":"Messages",
+      "RateUnit":"s",
+      "DurationUnit":"ms"
+    }]
+}

--- a/src/NServiceBus.Metrics.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Metrics.Tests
 {
     using System;
+    using System.IO;
     using System.Linq;
     using System.Runtime.CompilerServices;
     using ApprovalTests;
@@ -18,6 +19,16 @@
         {
             var publicApi = Filter(ApiGenerator.GeneratePublicApi(typeof(MetricsFeature).Assembly));
             Approvals.Verify(publicApi);
+        }
+
+        [Test]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [UseReporter(typeof(DiffReporter))]
+        public void ApproveMetrics()
+        {
+            var writer = new StringWriter();
+            AllMetrics.Define(writer);
+            Approvals.Verify(writer);
         }
 
         string Filter(string text)

--- a/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
+++ b/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="App_Packages\PublicApiGenerator.6.0.0\ApiGenerator.cs" />
     <Compile Include="APIApprovals.cs" />
     <Compile Include="ProcessingTime\ProcessingTimeCalculatorTests.cs" />
+    <Compile Include="StandardTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/NServiceBus.Metrics.Tests/StandardTests.cs
+++ b/src/NServiceBus.Metrics.Tests/StandardTests.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.Metrics.Tests
+{
+    using System.Linq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StandardTests
+    {
+        [Test]
+        public void AllMetrics_should_contain_all_builders()
+        {
+            var allBuilderTypes = from t in typeof(MetricsOptions).Assembly.GetTypes()
+                from i in t.GetInterfaces()
+                where
+                typeof(IMetricBuilder).IsAssignableFrom(t)
+                select t;
+
+            CollectionAssert.AreEquivalent(allBuilderTypes, AllMetrics.Create().Select(b => b.GetType()));
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/AllMetrics.cs
+++ b/src/NServiceBus.Metrics/AllMetrics.cs
@@ -1,0 +1,67 @@
+namespace NServiceBus.Metrics
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using global::Metrics;
+    using global::Metrics.Core;
+    using global::Metrics.Json;
+    using global::Metrics.MetricData;
+    using global::Metrics.Utils;
+
+    /// <summary>
+    /// Allows to define all avaible metrics
+    /// </summary>
+    public static class AllMetrics
+    {
+        internal static IMetricBuilder[] Create() => new IMetricBuilder[]
+        {
+            new PerformanceStatisticsMetricBuilder(),
+            new ProcessingTimeMetricBuilder(),
+            new CriticalTimeMetricBuilder()
+        };
+
+        /// <summary>
+        /// Outputs a raw json definition of all the defined metrics into the defined text writer.
+        /// </summary>
+        /// <param name="writer">The text writer.</param>
+        public static void Define(TextWriter writer)
+        {
+            var context = new StaticMetricsContext();
+            using (new MetricsConfig(context))
+            {
+                var builders = Create();
+                foreach (var builder in builders)
+                {
+                    builder.Define(context);
+                }
+
+                var metricsData = context.DataProvider.CurrentMetricsData;
+                writer.WriteLine(JsonBuilderV2.BuildJson(metricsData, Enumerable.Empty<EnvironmentEntry>(), new StaticClock(), true));
+            }
+        }
+
+        class StaticMetricsContext : BaseMetricsContext
+        {
+            static Clock staticClock = new StaticClock();
+
+            public StaticMetricsContext()
+                : this(string.Empty) { }
+
+            public StaticMetricsContext(string context)
+                : base(context, new DefaultMetricsRegistry(), new DefaultMetricsBuilder(), () => staticClock.UTCDateTime)
+            { }
+
+            protected override MetricsContext CreateChildContextInstance(string contextName)
+            {
+                return new StaticMetricsContext(contextName);
+            }
+        }
+
+        class StaticClock : Clock
+        {
+            public override long Nanoseconds { get; } = 0;
+            public override DateTime UTCDateTime { get; } = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified);
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/Builders.cs
+++ b/src/NServiceBus.Metrics/Builders.cs
@@ -1,9 +1,0 @@
-static class Builders
-{
-    public static IMetricBuilder[] Create() => new IMetricBuilder[]
-    {
-        new PerformanceStatisticsMetricBuilder(),
-        new ProcessingTimeMetricBuilder(),
-        new CriticalTimeMetricBuilder()
-    };
-}

--- a/src/NServiceBus.Metrics/Builders.cs
+++ b/src/NServiceBus.Metrics/Builders.cs
@@ -1,0 +1,9 @@
+static class Builders
+{
+    public static IMetricBuilder[] Create() => new IMetricBuilder[]
+    {
+        new PerformanceStatisticsMetricBuilder(),
+        new ProcessingTimeMetricBuilder(),
+        new CriticalTimeMetricBuilder()
+    };
+}

--- a/src/NServiceBus.Metrics/CriticalTime/CriticalTimeMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/CriticalTime/CriticalTimeMetricBuilder.cs
@@ -6,10 +6,15 @@ using NServiceBus.Features;
 
 class CriticalTimeMetricBuilder : IMetricBuilder
 {
-    public void WireUp(FeatureConfigurationContext featureConfigurationContext, MetricsContext metricsContext, Unit messagesUnit)
-    {
-        var criticalTimeTimer = metricsContext.Timer("Critical Time", messagesUnit);
+    Timer criticalTimeTimer;
 
+    public void Define(MetricsContext metricsContext)
+    {
+        criticalTimeTimer = metricsContext.Timer("Critical Time", Unit.Custom("Messages"));
+    }
+
+    public void WireUp(FeatureConfigurationContext featureConfigurationContext)
+    {
         featureConfigurationContext.Pipeline.OnReceivePipelineCompleted(e =>
         {
             DateTime timeSent;

--- a/src/NServiceBus.Metrics/IMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/IMetricBuilder.cs
@@ -3,5 +3,7 @@ using NServiceBus.Features;
 
 interface IMetricBuilder
 {
-    void WireUp(FeatureConfigurationContext featureConfigurationContext, MetricsContext metricsContext, Unit messagesUnit);
+    void Define(MetricsContext metricsContext);
+
+    void WireUp(FeatureConfigurationContext featureConfigurationContext);
 }

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Metrics;
 using NServiceBus;
@@ -26,39 +24,14 @@ class MetricsFeature : Feature
 
     static void ConfigureMetrics(FeatureConfigurationContext context, MetricsContext metricsContext)
     {
-        var messagesUnit = Unit.Custom("Messages");
+        var builders = Builders.Create();
 
-        ActivateAndInvoke<IMetricBuilder>(
-            context.Settings.GetAvailableTypes(),
-            builder => builder.WireUp(context, metricsContext, messagesUnit)
-        );
-    }
-
-    static void ForAllTypes<T>(IEnumerable<Type> types, Action<Type> action) where T : class
-    {
-        // ReSharper disable HeapView.SlowDelegateCreation
-        foreach (var type in types.Where(t => typeof(T).IsAssignableFrom(t) && !(t.IsAbstract || t.IsInterface)))
+        foreach (var builder in builders)
         {
-            action(type);
+            builder.Define(metricsContext);
+            builder.WireUp(context);
         }
-        // ReSharper restore HeapView.SlowDelegateCreation
     }
-
-    static void ActivateAndInvoke<T>(IList<Type> types, Action<T> action) where T : class
-    {
-        ForAllTypes<T>(types, t =>
-        {
-            if (!HasDefaultConstructor(t))
-            {
-                throw new Exception($"Unable to create the type '{t.Name}'. Types implementing '{typeof(T).Name}' must have a public parameterless (default) constructor.");
-            }
-
-            var instanceToInvoke = (T)Activator.CreateInstance(t);
-            action(instanceToInvoke);
-        });
-    }
-
-    static bool HasDefaultConstructor(Type type) => type.GetConstructor(Type.EmptyTypes) != null;
 
     class MetricsReporting : FeatureStartupTask
     {

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Metrics;
 using NServiceBus;
 using NServiceBus.Features;
+using NServiceBus.Metrics;
 using NServiceBus.ObjectBuilder;
 
 class MetricsFeature : Feature
@@ -24,7 +25,7 @@ class MetricsFeature : Feature
 
     static void ConfigureMetrics(FeatureConfigurationContext context, MetricsContext metricsContext)
     {
-        var builders = Builders.Create();
+        var builders = AllMetrics.Create();
 
         foreach (var builder in builders)
         {

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Metrics;
 using NServiceBus;
 using NServiceBus.Features;
@@ -36,10 +35,6 @@ class MetricsFeature : Feature
 
     class MetricsReporting : FeatureStartupTask
     {
-        MetricsOptions metricsOptions;
-        IBuilder builder;
-        MetricsConfig metricsConfig;
-
         public MetricsReporting(MetricsContext metricsContext, MetricsOptions metricsOptions, IBuilder builder)
         {
             this.metricsOptions = metricsOptions;
@@ -58,5 +53,9 @@ class MetricsFeature : Feature
             metricsConfig.Dispose();
             return Task.FromResult(0);
         }
+
+        MetricsOptions metricsOptions;
+        IBuilder builder;
+        MetricsConfig metricsConfig;
     }
 }

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -64,8 +64,7 @@
   <ItemGroup>
     <Compile Include="CriticalTime\CriticalTimeMetricBuilder.cs" />
     <Compile Include="IMetricBuilder.cs" />
-    <Compile Include="MeterDefinitionSettingsAttribute.cs" />
-    <Compile Include="Builders.cs" />
+    <Compile Include="AllMetrics.cs" />
     <Compile Include="Performance\PerformanceStatisticsMetricBuilder.cs" />
     <Compile Include="Performance\ReceivePerformanceDiagnosticsBehavior.cs" />
     <Compile Include="ProcessingTime\ProcessingTimeMetricBuilder.cs" />

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -64,6 +64,8 @@
   <ItemGroup>
     <Compile Include="CriticalTime\CriticalTimeMetricBuilder.cs" />
     <Compile Include="IMetricBuilder.cs" />
+    <Compile Include="MeterDefinitionSettingsAttribute.cs" />
+    <Compile Include="Builders.cs" />
     <Compile Include="Performance\PerformanceStatisticsMetricBuilder.cs" />
     <Compile Include="Performance\ReceivePerformanceDiagnosticsBehavior.cs" />
     <Compile Include="ProcessingTime\ProcessingTimeMetricBuilder.cs" />

--- a/src/NServiceBus.Metrics/Performance/PerformanceStatisticsMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/Performance/PerformanceStatisticsMetricBuilder.cs
@@ -3,12 +3,19 @@ using NServiceBus.Features;
 
 class PerformanceStatisticsMetricBuilder : IMetricBuilder
 {
-    public void WireUp(FeatureConfigurationContext featureConfigurationContext, MetricsContext metricsContext, Unit messagesUnit)
-    {
-        var messagesPulledFromQueueMeter = metricsContext.Meter("# of messages pulled from the input queue / sec", messagesUnit);
-        var failureRateMeter = metricsContext.Meter("# of message failures / sec", messagesUnit);
-        var successRateMeter = metricsContext.Meter("# of messages successfully processed / sec", messagesUnit);
+    Meter messagesPulledFromQueueMeter;
+    Meter failureRateMeter;
+    Meter successRateMeter;
 
+    public void Define(MetricsContext metricsContext)
+    {
+        messagesPulledFromQueueMeter = metricsContext.Meter("# of messages pulled from the input queue / sec", Unit.Custom("Messages"));
+        failureRateMeter = metricsContext.Meter("# of message failures / sec", Unit.Custom("Messages"));
+        successRateMeter = metricsContext.Meter("# of messages successfully processed / sec", Unit.Custom("Messages"));
+    }
+
+    public void WireUp(FeatureConfigurationContext featureConfigurationContext)
+    {
         var performanceDiagnosticsBehavior = new ReceivePerformanceDiagnosticsBehavior(
             messagesPulledFromQueueMeter,
             failureRateMeter,

--- a/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeCalculator.cs
+++ b/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeCalculator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-class ProcessingTimeCalculator
+static class ProcessingTimeCalculator
 {
     public static TimeSpan Calculate(DateTime startedAt, DateTime completedAt) => completedAt - startedAt;
 }

--- a/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
@@ -5,10 +5,15 @@ using NServiceBus.Features;
 
 class ProcessingTimeMetricBuilder : IMetricBuilder
 {
-    public void WireUp(FeatureConfigurationContext featureConfigurationContext, MetricsContext metricsContext, Unit messagesUnit)
-    {
-        var processingTimeTimer = metricsContext.Timer("Processing Time", messagesUnit);
+    Timer processingTimeTimer;
 
+    public void Define(MetricsContext metricsContext)
+    {
+        processingTimeTimer = metricsContext.Timer("Processing Time", Unit.Custom("Messages"));
+    }
+
+    public void WireUp(FeatureConfigurationContext featureConfigurationContext)
+    {
         featureConfigurationContext.Pipeline.OnReceivePipelineCompleted(e =>
         {
             var processingTimeInMilliseconds = ProcessingTimeCalculator.Calculate(e.StartedAt, e.CompletedAt).TotalMilliseconds;


### PR DESCRIPTION
We realized that we have a problem with the performance counters. Before you can create a performance counter instance you have to declare a performance counter definition. You can do it with powershell or csharp. Currently the performance counter package relies on [NServiceBus.Powershell](https://github.com/Particular/NServiceBus.PowerShell/blob/develop/src/NServiceBus.PowerShell/PerformanceCounters/PerformanceCounterSetup.cs#L52) to do this. Now here comes the caveat. if we ever add in NServiceBus.Metrics a gauge, a meter or a timer that is not defined in the powershell the instantiation of the counter will fail. Therefore any addition in the metrics package will essentially make the code break.

So we thought it is a good idea to use the JSon format as a "schema" that can be generated. This would allow us the following:

NServiceBus.Metrics.PerformanceCounters can call AllMetrics.Define(textWriter) and let the metrics package dump all metrics into a definition file (we can do that at compile time, need to double check with @SimonCropp ). The we use the json file to dynamically create powershell and/or chsarp code that is put into the output folder. When the user starts the code and it tries to create a performance counter that is not yet defined, the exception will point to the output folder instructing the user to run the script. With that the performance counter package has the knowledge of translating meters, timers... into performance counter definitions and performance counter types. Furthermore we can deprecate the powershell script that are in NServiceBus.Powershell. So the performance counter repo becomes self contained. 

Thoughts?