### PR TITLE
Adding description to the MetricAttribute

### DIFF
--- a/src/NServiceBus.Metrics/Core/MeterAttribute.cs
+++ b/src/NServiceBus.Metrics/Core/MeterAttribute.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Metrics
         /// <summary>
         /// Defines a meter
         /// </summary>
-        public MeterAttribute(string name, string unit, string[] tags = null) : base(name, unit, tags)
+        public MeterAttribute(string name, string unit, string description, string[] tags = null) : base(name, unit, description, tags)
         {
         }
 

--- a/src/NServiceBus.Metrics/Core/MetricAttribute.cs
+++ b/src/NServiceBus.Metrics/Core/MetricAttribute.cs
@@ -12,10 +12,11 @@ namespace NServiceBus.Metrics
         /// <summary>
         /// Creates new metric attribute.
         /// </summary>
-        protected MetricAttribute(string name, string unit, string[] tags = null)
+        protected MetricAttribute(string name, string unit, string description, string[] tags = null)
         {
             Name = name;
             Unit = unit;
+            Description = description;
             Tags = tags;
         }
 
@@ -28,6 +29,11 @@ namespace NServiceBus.Metrics
         /// Unit of measure
         /// </summary>
         public string Unit { get; }
+
+        /// <summary>
+        /// Description.
+        /// </summary>
+        public string Description { get; }
 
         /// <summary>
         /// Optional tags

--- a/src/NServiceBus.Metrics/Core/TimerAttribute.cs
+++ b/src/NServiceBus.Metrics/Core/TimerAttribute.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Metrics
         /// <summary>
         /// Defines a timer.
         /// </summary>
-        public TimerAttribute(string name, string unit, string[] tags = null) : base(name, unit, tags)
+        public TimerAttribute(string name, string unit, string description, string[] tags = null) : base(name, unit, description, tags)
         {
         }
 

--- a/src/NServiceBus.Metrics/CriticalTime/CriticalTimeMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/CriticalTime/CriticalTimeMetricBuilder.cs
@@ -23,6 +23,6 @@ class CriticalTimeMetricBuilder : MetricBuilder
         });
     }
 
-    [Timer("Critical Time", "Messages")]
+    [Timer("Critical Time", "Messages", "Age of the oldest message in the queue.")]
     Timer criticalTimeTimer = default(Timer);
 }

--- a/src/NServiceBus.Metrics/Performance/PerformanceStatisticsMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/Performance/PerformanceStatisticsMetricBuilder.cs
@@ -19,12 +19,12 @@ class PerformanceStatisticsMetricBuilder : MetricBuilder
         );
     }
 
-    [Meter("# of messages pulled from the input queue / sec", "Messages")]
+    [Meter("# of messages pulled from the input queue / sec", "Messages", "The current number of messages pulled from the input queue by the transport per second.")]
     Meter messagesPulledFromQueueMeter = default(Meter);
 
-    [Meter("# of message failures / sec", "Messages")]
+    [Meter("# of message failures / sec", "Messages", "The current number of failed processed messages by the transport per second.")]
     Meter failureRateMeter = default(Meter);
 
-    [Meter("# of messages successfully processed / sec", "Messages")]
+    [Meter("# of messages successfully processed / sec", "Messages", "The current number of messages processed successfully by the transport per second.")]
     Meter successRateMeter = default(Meter);
 }

--- a/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
@@ -21,6 +21,6 @@ class ProcessingTimeMetricBuilder : MetricBuilder
         });
     }
 
-    [Timer("Processing Time", "Messages")]
+    [Timer("Processing Time", "Messages", "The time it took to successfully process a message.")]
     Timer processingTimeTimer = default(Timer);
 }


### PR DESCRIPTION
Allows interested downstream like PerformanceCounters to parse the description. The description will not be shipped to the backend or to the custom reporter. It is pure metadata.