### PR TITLE
Revert "Aligned with legacy names"

### DIFF
--- a/src/NServiceBus.Metrics.AcceptanceTests/PayloadAssert.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/PayloadAssert.cs
@@ -18,9 +18,9 @@ public static class PayloadAssert
 
     static List<string> meters = new List<string>
     {
-        "# of msgs failures / sec",
-        "# of msgs pulled from the input queue / sec",
-        "# of msgs successfully processed / sec",
+        "# of message failures / sec",
+        "# of messages pulled from the input queue / sec",
+        "# of messages successfully processed / sec",
         "Critical Time",
         "Processing Time"
     };

--- a/src/NServiceBus.Metrics/Performance/PerformanceStatisticsMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/Performance/PerformanceStatisticsMetricBuilder.cs
@@ -19,12 +19,12 @@ class PerformanceStatisticsMetricBuilder : MetricBuilder
         );
     }
 
-    [Meter("# of msgs pulled from the input queue / sec", "Messages", "The current number of messages pulled from the input queue by the transport per second.")]
+    [Meter("# of messages pulled from the input queue / sec", "Messages", "The current number of messages pulled from the input queue by the transport per second.")]
     Meter messagesPulledFromQueueMeter = default(Meter);
 
-    [Meter("# of msgs failures / sec", "Messages", "The current number of failed processed messages by the transport per second.")]
+    [Meter("# of message failures / sec", "Messages", "The current number of failed processed messages by the transport per second.")]
     Meter failureRateMeter = default(Meter);
 
-    [Meter("# of msgs successfully processed / sec", "Messages", "The current number of messages processed successfully by the transport per second.")]
+    [Meter("# of messages successfully processed / sec", "Messages", "The current number of messages processed successfully by the transport per second.")]
     Meter successRateMeter = default(Meter);
 }


### PR DESCRIPTION
Reverts Particular/NServiceBus.Metrics#26

Discussed with @mikeminutillo @SzymonPobiega @WojcikMike and I think it is safer to go back to the mapped names in the perf counters. Therefore this PR can be reverted