### PR TITLE
Metrics fixes

### DIFF
--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -17,9 +17,11 @@ class MetricsFeature : Feature
     {
         context.ThrowIfSendonly();
 
-        context.RegisterMetricBuilder(new CriticalTimeMetricBuilder());
+        var resetMetricTimer = new ResetMetricTimer(context);
+
+        context.RegisterMetricBuilder(new CriticalTimeMetricBuilder(resetMetricTimer));
         context.RegisterMetricBuilder(new PerformanceStatisticsMetricBuilder());
-        context.RegisterMetricBuilder(new ProcessingTimeMetricBuilder());
+        context.RegisterMetricBuilder(new ProcessingTimeMetricBuilder(resetMetricTimer));
         context.RegisterMetricBuilder(new QueueLengthMetricBuilder());
 
         var settings = context.Settings;

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Reporters\TraceReport.cs" />
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="InternalsVisibleTo.cs" />
+    <Compile Include="ResetMetricTimer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NServiceBus.snk" />

--- a/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Metrics;
 using NServiceBus;

--- a/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
@@ -34,6 +34,6 @@ class ProcessingTimeMetricBuilder : MetricBuilder
         });
     }
 
-    [Timer("Processing Time", "Messages", "Age of the oldest message in the queue.")]
+    [Timer("Processing Time", "Messages", "The time it took to successfully process a message.")]
     Timer processingTimeTimer = default(Timer);
 }

--- a/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
+++ b/src/NServiceBus.Metrics/ProcessingTime/ProcessingTimeMetricBuilder.cs
@@ -25,8 +25,6 @@ class ProcessingTimeMetricBuilder : MetricBuilder
         {
             var processingTimeInMilliseconds = ProcessingTimeCalculator.Calculate(e.StartedAt, e.CompletedAt).TotalMilliseconds;
 
-            Console.WriteLine($"ProcTime : {e.StartedAt} to {e.CompletedAt} = {processingTimeInMilliseconds}");
-
             string messageTypeProcessed;
             e.TryGetMessageType(out messageTypeProcessed);
 

--- a/src/NServiceBus.Metrics/ResetMetricTimer.cs
+++ b/src/NServiceBus.Metrics/ResetMetricTimer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Features;
+
+class ResetMetricTimer
+{
+    public event EventHandler NoMessageSentForAWhile;
+
+    public ResetMetricTimer(FeatureConfigurationContext featureConfigurationContext)
+    {
+        timer = new System.Threading.Timer(ResetCounterValueIfNoMessageHasBeenProcessedRecently, null, 0, 2000);
+
+        featureConfigurationContext.Pipeline.OnReceivePipelineCompleted(e =>
+        {
+            DateTime timeSent;
+            if (e.TryGetTimeSent(out timeSent))
+            {
+                lastMessageProcessedTime = e.CompletedAt;
+            }
+
+            return Task.FromResult(0);
+        });
+
+    }
+
+    void ResetCounterValueIfNoMessageHasBeenProcessedRecently(object state)
+    {
+        // Concurreny : This runs every 2s and might just fire before an update
+        if (NoMessageHasBeenProcessedRecently())
+        {
+            NoMessageSentForAWhile?.Invoke(this, null);
+        }
+    }
+
+    bool NoMessageHasBeenProcessedRecently()
+    {
+        var timeFromLastMessageProcessed = DateTime.UtcNow - lastMessageProcessedTime;
+        // Concurrency : This currently ignores messages being processed atm.
+        return timeFromLastMessageProcessed > estimatedMaximumProcessingDuration;
+    }
+
+    TimeSpan estimatedMaximumProcessingDuration = TimeSpan.FromSeconds(2);
+    DateTime lastMessageProcessedTime;
+    System.Threading.Timer timer; // We need this member or GC will dispose timer immediately.
+}

--- a/src/NServiceBus.Metrics/ResetMetricTimer.cs
+++ b/src/NServiceBus.Metrics/ResetMetricTimer.cs
@@ -42,5 +42,6 @@ class ResetMetricTimer
 
     TimeSpan estimatedMaximumProcessingDuration = TimeSpan.FromSeconds(2);
     DateTime lastMessageProcessedTime;
+    // ReSharper disable once NotAccessedField.Local
     System.Threading.Timer timer; // We need this member or GC will dispose timer immediately.
 }


### PR DESCRIPTION
Connected to https://github.com/Particular/NServiceBus.Metrics.PerformanceCounters/issues/11

(re)introduces timer to reset counters to 0 when no mesages are being processed

ping @Particular/metrics-maintainers 