### PR TITLE
Reporting raw data

### DIFF
--- a/src/NServiceBus.Metrics.Tests/RawData/LongValueWriterTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/LongValueWriterTests.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.Metrics.Tests.RawData
+{
+    using Metrics.RawData;
+    using NUnit.Framework;
+
+    public class LongValueWriterTests : WriterTestBase
+    {
+        public LongValueWriterTests() 
+            : base(LongValueWriter.Write)
+        {
+        }
+
+        [Test]
+        public void Writing_one_value()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+            const long value = 3;
+
+            var entry = new RingBuffer.Entry { Ticks = ticks, Value = value };
+            Write(entry);
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(0);
+                writer.Write(value);
+            });
+        }
+
+        [Test]
+        public void Writing_two_values_sorted_by_date()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+            const long value1 = 3;
+            const long value2 = value1 + 1;
+            const int timeDiff = 1;
+
+            Write(
+                new RingBuffer.Entry(ticks + timeDiff, value2),
+                new RingBuffer.Entry(ticks, value1)
+                );
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(0);
+                writer.Write(value1);
+                writer.Write(timeDiff);
+                writer.Write(value2);
+            });
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.Tests/RawData/LongValueWriterTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/LongValueWriterTests.cs
@@ -24,6 +24,7 @@
             {
                 writer.Write(version);
                 writer.Write(ticks);
+                writer.Write(1);
                 writer.Write(0);
                 writer.Write(value);
             });
@@ -47,6 +48,7 @@
             {
                 writer.Write(version);
                 writer.Write(ticks);
+                writer.Write(2);
                 writer.Write(0);
                 writer.Write(value1);
                 writer.Write(timeDiff);

--- a/src/NServiceBus.Metrics.Tests/RawData/OccurrenceWriterTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/OccurrenceWriterTests.cs
@@ -1,0 +1,51 @@
+﻿namespace NServiceBus.Metrics.Tests.RawData
+{
+    using Metrics.RawData;
+    using NUnit.Framework;
+
+    public class OccurrenceWriterTests : WriterTestBase
+    {
+        public OccurrenceWriterTests()
+            : base(OccurrenceWriter.Write)
+        {
+        }
+
+        [Test]
+        public void Writing_one_value()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+
+            var entry = new RingBuffer.Entry { Ticks = ticks, Value = 23544345345 };
+            Write(entry);
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(0);
+            });
+        }
+
+        [Test]
+        public void Writing_two_values_sorted_by_date()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+            const int timeDiff = 1;
+
+            Write(
+                new RingBuffer.Entry(ticks + timeDiff, 8902374857238758343),
+                new RingBuffer.Entry(ticks, 390489580934859034)
+            );
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(0);
+                writer.Write(timeDiff);
+            });
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.Tests/RawData/OccurrenceWriterTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/OccurrenceWriterTests.cs
@@ -23,6 +23,7 @@
             {
                 writer.Write(version);
                 writer.Write(ticks);
+                writer.Write(1);
                 writer.Write(0);
             });
         }
@@ -43,6 +44,7 @@
             {
                 writer.Write(version);
                 writer.Write(ticks);
+                writer.Write(2);
                 writer.Write(0);
                 writer.Write(timeDiff);
             });

--- a/src/NServiceBus.Metrics.Tests/RawData/RawDataReporterTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/RawDataReporterTests.cs
@@ -31,7 +31,7 @@
         [Test]
         public async Task When_flush_size_is_reached()
         {
-            var reporter = new RawDataReporter(dispatcher, Destination, HostInformation, buffer, MessageTypeName, EndpointName, WriteEntriesValues, 4, TimeSpan.MaxValue);
+            var reporter = new RawDataReporter(dispatcher, Destination, new Dictionary<string, string>(), buffer, WriteEntriesValues, 4, TimeSpan.MaxValue);
             reporter.Start();
             buffer.TryWrite(1);
             buffer.TryWrite(2);
@@ -48,7 +48,7 @@
         {
             var maxSpinningTime = TimeSpan.FromMilliseconds(100);
 
-            var reporter = new RawDataReporter(dispatcher, Destination, HostInformation, buffer, MessageTypeName, EndpointName, WriteEntriesValues, int.MaxValue, maxSpinningTime);
+            var reporter = new RawDataReporter(dispatcher, Destination, new Dictionary<string, string>(), buffer, WriteEntriesValues, int.MaxValue, maxSpinningTime);
             reporter.Start();
             buffer.TryWrite(1);
             buffer.TryWrite(2);
@@ -62,7 +62,7 @@
         [Test]
         public async Task When_stopped()
         {
-            var reporter = new RawDataReporter(dispatcher, Destination, HostInformation, buffer, MessageTypeName, EndpointName, WriteEntriesValues, int.MaxValue, TimeSpan.MaxValue);
+            var reporter = new RawDataReporter(dispatcher, Destination, new Dictionary<string, string>(), buffer, WriteEntriesValues, int.MaxValue, TimeSpan.MaxValue);
             reporter.Start();
             buffer.TryWrite(1);
             buffer.TryWrite(2);

--- a/src/NServiceBus.Metrics.Tests/RawData/RawDataReporterTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/RawDataReporterTests.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.Metrics.Tests.RawData
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Hosting;
+    using Metrics.RawData;
+    using NUnit.Framework;
+    using Transport;
+
+    public class RawDataReporterTests
+    {
+        static readonly HostInformation HostInformation = new HostInformation(Guid.NewGuid(), "display-name");
+        RingBuffer buffer;
+        MockDispatcher dispatcher;
+        const string Destination = "destination";
+        const string MessageTypeName = "message.type.name";
+        const string EndpointName = "endpoint.name";
+
+        [SetUp]
+        public void SetUp()
+        {
+            buffer = new RingBuffer();
+            dispatcher = new MockDispatcher();
+        }
+
+        [Test]
+        public async Task When_flush_size_is_reached()
+        {
+            var reporter = new RawDataReporter(dispatcher, Destination, HostInformation, buffer, MessageTypeName, EndpointName, WriteEntriesValues, 4, TimeSpan.MaxValue);
+            reporter.Start();
+            buffer.TryWrite(1);
+            buffer.TryWrite(2);
+            buffer.TryWrite(3);
+            buffer.TryWrite(4);
+            
+            Assert(new long[]{1,2,3,4});
+
+            await reporter.Stop();
+        }
+
+        [Test]
+        public async Task When_max_spinning_time_is_reached()
+        {
+            var maxSpinningTime = TimeSpan.FromMilliseconds(100);
+
+            var reporter = new RawDataReporter(dispatcher, Destination, HostInformation, buffer, MessageTypeName, EndpointName, WriteEntriesValues, int.MaxValue, maxSpinningTime);
+            reporter.Start();
+            buffer.TryWrite(1);
+            buffer.TryWrite(2);
+            await Task.Delay(maxSpinningTime.Add(TimeSpan.FromMilliseconds(200)));
+            
+            Assert(new long[] { 1, 2 });
+
+            await reporter.Stop();
+        }
+
+        [Test]
+        public async Task When_stopped()
+        {
+            var reporter = new RawDataReporter(dispatcher, Destination, HostInformation, buffer, MessageTypeName, EndpointName, WriteEntriesValues, int.MaxValue, TimeSpan.MaxValue);
+            reporter.Start();
+            buffer.TryWrite(1);
+            buffer.TryWrite(2);
+            
+            await reporter.Stop();
+
+            Assert(new long[] { 1, 2 });
+        }
+
+        void Assert(params long[][] values)
+        {
+            var operations = dispatcher.Operations.ToArray();
+            var i = 0;
+            foreach (var operation in operations)
+            {
+                var op = operation.UnicastTransportOperations.Single();
+
+                var encodedValues = new List<long>();
+                var reader = new BinaryReader(new MemoryStream(op.Message.Body));
+                while (reader.BaseStream.Position < reader.BaseStream.Length)
+                {
+                    encodedValues.Add(reader.ReadInt64());
+                }
+
+                CollectionAssert.AreEqual(values[i], encodedValues);
+            }
+        }
+
+        static void WriteEntriesValues(ArraySegment<RingBuffer.Entry> entries, BinaryWriter writer)
+        {
+            foreach (var entry in entries)
+            {
+                writer.Write(entry.Value);
+            }
+        }
+
+        class MockDispatcher : IDispatchMessages
+        {
+            public ConcurrentQueue<TransportOperations> Operations = new ConcurrentQueue<TransportOperations>();
+
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
+            {
+                Operations.Enqueue(outgoingMessages);
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.Tests/RawData/RingBufferTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/RingBufferTests.cs
@@ -66,6 +66,37 @@
         }
 
         [Test]
+        public void Estimate_just_initialized_ring_size()
+        {
+            // This test is single threaded so no cross-thread aberrations will be visible.
+
+            Assert.AreEqual(0, ringBuffer.RoughlyEstimateItemsToConsume());
+        }
+
+        [Test]
+        public void Estimate_empty_ring_size()
+        {
+            // This test is single threaded so no cross-thread aberrations will be visible.
+
+            var values = Enumerable.Repeat(1, RingBuffer.Size).Select(i => (long)i).ToArray();
+            WriteValues(values);
+            Consume(values);
+
+            Assert.AreEqual(0, ringBuffer.RoughlyEstimateItemsToConsume());
+        }
+
+        [Test]
+        public void Estimate_full_ring_size()
+        {
+            // This test is single threaded so no cross-thread aberrations will be visible.
+
+            var values = Enumerable.Repeat(1, RingBuffer.Size).Select(i => (long)i).ToArray();
+            WriteValues(values);
+
+            Assert.AreEqual(RingBuffer.Size, ringBuffer.RoughlyEstimateItemsToConsume());
+        }
+
+        [Test]
         public Task Concurrent_test()
         {
             const int size = 100000;

--- a/src/NServiceBus.Metrics.Tests/RawData/RingBufferTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/RingBufferTests.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.Metrics.Tests.RawData
+{
+    using System.Linq;
+    using Metrics.RawData;
+    using NUnit.Framework;
+
+    public class RingBufferTests
+    {
+        RingBuffer ringBuffer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            ringBuffer = new RingBuffer();
+        }
+
+        [Test]
+        public void Writing_several_entries()
+        {
+            var values = new long[] { 1, 2, 3, 4 };
+
+            WriteValues(values);
+
+            Consume(values);
+            Consume();
+        }
+
+        [Test]
+        public void Writing_over_size_should_not_succeed()
+        {
+            var values = Enumerable.Repeat(1, RingBuffer.Size).Select(i => (long)i).ToArray();
+            WriteValues(values);
+
+            Assert.False(ringBuffer.TryWrite(long.MaxValue));
+
+            Consume(values);
+            Consume();
+        }
+
+        [Test]
+        public void Overlapping_buffer_should_be_consumed_till_end_and_again()
+        {
+            var values = Enumerable.Repeat(1, RingBuffer.Size - 2).Select(i => (long)i).ToArray();
+            WriteValues(values);
+            Consume(values);
+            Consume();
+
+            WriteValues(1, 2, 3, 4);
+
+            Consume(1, 2);
+            Consume(3, 4);
+            Consume();
+        }
+
+        void Consume(params long[] values)
+        {
+            var read = ringBuffer.Consume(entries =>
+            {
+                CollectionAssert.AreEqual(values, entries.Select(e => e.Value).ToArray());
+            });
+
+            Assert.AreEqual(values.Length, read);
+        }
+
+        void WriteValues(params long[] values)
+        {
+            foreach (var value in values)
+            {
+                Assert.True(ringBuffer.TryWrite(value));
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.Tests/RawData/WriterTestBase.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/WriterTestBase.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Metrics.Tests.RawData
     using Metrics.RawData;
     using NUnit.Framework;
 
-    public abstract class WriterTestBase
+    public abstract class WriterTestBase : IDisposable
     {
         MemoryStream ms;
         BinaryWriter bw;
@@ -40,12 +40,22 @@ namespace NServiceBus.Metrics.Tests.RawData
 
         protected void Assert(Action<BinaryWriter> write)
         {
-            var stream = new MemoryStream();
-            var writer = new BinaryWriter(stream);
-            write(writer);
-            writer.Flush();
+            using (var stream = new MemoryStream())
+            {
+                using (var binaryWriter = new BinaryWriter(stream))
+                {
+                    write(binaryWriter);
+                    binaryWriter.Flush();
+                }
 
-            CollectionAssert.AreEqual(stream.ToArray(), ms.ToArray());
+                CollectionAssert.AreEqual(stream.ToArray(), ms.ToArray());
+            }
+        }
+
+        public void Dispose()
+        {
+            bw?.Dispose();
+            ms?.Dispose();
         }
     }
 }

--- a/src/NServiceBus.Metrics.Tests/RawData/WriterTestBase.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/WriterTestBase.cs
@@ -1,0 +1,51 @@
+namespace NServiceBus.Metrics.Tests.RawData
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using Metrics.RawData;
+    using NUnit.Framework;
+
+    public abstract class WriterTestBase
+    {
+        MemoryStream ms;
+        BinaryWriter bw;
+        Action<BinaryWriter, ArraySegment<RingBuffer.Entry>> writer;
+
+        internal WriterTestBase(Action<BinaryWriter, ArraySegment<RingBuffer.Entry>> writer)
+        {
+            ms = new MemoryStream();
+            bw = new BinaryWriter(ms);
+            this.writer = writer;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            bw.Flush();
+            ms.SetLength(0);
+        }
+
+        internal void Write(params RingBuffer.Entry[] entries)
+        {
+            // put additional values in front and at the end to make it a real segment
+            var list = entries.ToList();
+            list.Insert(0, new RingBuffer.Entry());
+            list.Add(new RingBuffer.Entry());
+
+            writer(bw, new ArraySegment<RingBuffer.Entry>(list.ToArray(), 1, entries.Length));
+
+            bw.Flush();
+        }
+
+        protected void Assert(Action<BinaryWriter> write)
+        {
+            var stream = new MemoryStream();
+            var writer = new BinaryWriter(stream);
+            write(writer);
+            writer.Flush();
+
+            CollectionAssert.AreEqual(stream.ToArray(), ms.ToArray());
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -227,7 +227,7 @@ class MetricsFeature : Feature
 
         protected override async Task OnStop(IMessageSession session)
         {
-            await Task.WhenAll(criticalTimeReporter.Stop(), processingTimeReporter.Stop());
+            await Task.WhenAll(criticalTimeReporter.Stop(), processingTimeReporter.Stop()).ConfigureAwait(false);
 
             criticalTimeReporter.Dispose();
             processingTimeReporter.Dispose();

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -1,10 +1,13 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Metrics;
 using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Hosting;
+using NServiceBus.Logging;
 using NServiceBus.Metrics.QueueLength;
+using NServiceBus.Metrics.RawData;
 using NServiceBus.ObjectBuilder;
 using NServiceBus.Transport;
 
@@ -50,6 +53,7 @@ class MetricsFeature : Feature
             SetUpSignalReporting(probeContext, metricsContext);
 
             context.RegisterStartupTask(builder => new ServiceControlReporting(metricsContext, builder, metricsOptions));
+            context.RegisterStartupTask(builder => new ServiceControlRawDataReporting(probeContext.Durations, builder, metricsOptions, endpointName));
         }
     }
 
@@ -138,5 +142,90 @@ class MetricsFeature : Feature
         IBuilder builder;
         MetricsOptions options;
         MetricsConfig metricsConfig;
+    }
+
+    class ServiceControlRawDataReporting : FeatureStartupTask
+    {
+        IReadOnlyCollection<IDurationProbe> probes;
+        IBuilder builder;
+        MetricsOptions options;
+        string endpointName;
+        RawDataReporter processingTimeReporter;
+        RawDataReporter criticalTimeReporter;
+
+        public ServiceControlRawDataReporting(IReadOnlyCollection<IDurationProbe> probes, IBuilder builder, MetricsOptions options, string endpointName)
+        {
+            this.probes = probes;
+            this.builder = builder;
+            this.options = options;
+            this.endpointName = endpointName;
+        }
+
+        protected override Task OnStart(IMessageSession session)
+        {
+            foreach (var durationProbe in probes)
+            {
+                if (durationProbe.Name == ProcessingTimeProbeBuilder.ProcessingTime)
+                {
+                    processingTimeReporter = CreateRawDataReporter(durationProbe);
+                }
+
+                if (durationProbe.Name == CriticalTimeProbeBuilder.CriticalTime)
+                {
+                    criticalTimeReporter = CreateRawDataReporter(durationProbe);
+                }
+            }
+
+            processingTimeReporter.Start();
+            criticalTimeReporter.Start();
+
+            return Task.FromResult(0);
+        }
+
+        RawDataReporter CreateRawDataReporter(IDurationProbe probe)
+        {
+            var buffer = new RingBuffer();
+
+            var reporter = new RawDataReporter(
+                builder.Build<IDispatchMessages>(),
+                options.ServiceControlMetricsAddress,
+                builder.Build<HostInformation>(),
+                buffer,
+                probe.Name.Replace(" ", string.Empty),
+                endpointName,
+                (entries, writer) => LongValueWriter.Write(writer, entries));
+
+            probe.Register(ct =>
+            {
+                var written = false;
+                var attempts = 0;
+
+                while (!written)
+                {
+                    written = buffer.TryWrite((long)ct.TotalMilliseconds);
+
+                    attempts++;
+
+                    if (attempts >= MaxExpectedWriteAttempts)
+                    {
+                        log.Warn($"Failed to buffer timing metrics data after ${attempts} attempts.");
+                        attempts = 0;
+                    }
+                }
+            });
+
+            return reporter;
+        }
+
+        protected override async Task OnStop(IMessageSession session)
+        {
+            await Task.WhenAll(criticalTimeReporter.Stop(), processingTimeReporter.Stop());
+
+            criticalTimeReporter.Dispose();
+            processingTimeReporter.Dispose();
+        }
+
+        static int MaxExpectedWriteAttempts = 10;
+        static ILog log = LogManager.GetLogger<ServiceControlRawDataReporting>();
     }
 }

--- a/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
@@ -3,9 +3,11 @@ using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Metrics;
 
-[ProbeProperties("Critical Time", "The time it took from sending to processing the message.")]
+[ProbeProperties(CriticalTime, "The time it took from sending to processing the message.")]
 class CriticalTimeProbeBuilder : DurationProbeBuilder
 {
+    public const string CriticalTime = "Critical Time";
+
     public CriticalTimeProbeBuilder(FeatureConfigurationContext context)
     {
         this.context = context;

--- a/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
@@ -2,7 +2,7 @@ using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Metrics;
 
-[ProbeProperties("Processing Time", "The time it took to successfully process a message.")]
+[ProbeProperties(ProcessingTime, "The time it took to successfully process a message.")]
 class ProcessingTimeProbeBuilder : DurationProbeBuilder
 {
     public ProcessingTimeProbeBuilder(FeatureConfigurationContext context)
@@ -24,6 +24,8 @@ class ProcessingTimeProbeBuilder : DurationProbeBuilder
             return TaskExtensions.Completed;
         });
     }
-
+    
     readonly FeatureConfigurationContext context;
+
+    public const string ProcessingTime = "Processing Time";
 }

--- a/src/NServiceBus.Metrics/RawData/EntryTickComparer.cs
+++ b/src/NServiceBus.Metrics/RawData/EntryTickComparer.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Metrics.RawData
+{
+    using System.Collections.Generic;
+
+    class EntryTickComparer : IComparer<RingBuffer.Entry>
+    {
+        public static readonly EntryTickComparer Instance = new EntryTickComparer();
+
+        EntryTickComparer() { }
+
+        public int Compare(RingBuffer.Entry x, RingBuffer.Entry y)
+        {
+            return x.Ticks.CompareTo(y.Ticks);
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/RawData/LongValueWriter.cs
+++ b/src/NServiceBus.Metrics/RawData/LongValueWriter.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Metrics.RawData
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
 
     static class LongValueWriter
@@ -37,18 +36,6 @@
                 var date = (int)(array[offset + i].Ticks - minDate);
                 outputWriter.Write(date);
                 outputWriter.Write(array[offset + i].Value);
-            }
-        }
-
-        class EntryTickComparer : IComparer<RingBuffer.Entry>
-        {
-            public static readonly EntryTickComparer Instance = new EntryTickComparer();
-
-            EntryTickComparer() { }
-
-            public int Compare(RingBuffer.Entry x, RingBuffer.Entry y)
-            {
-                return x.Ticks.CompareTo(y.Ticks);
             }
         }
     }

--- a/src/NServiceBus.Metrics/RawData/LongValueWriter.cs
+++ b/src/NServiceBus.Metrics/RawData/LongValueWriter.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.Metrics.RawData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    static class LongValueWriter
+    {
+        const long Version = 1;
+
+        // WIRE FORMAT, Version: 1
+
+        // 0                   1                   2                   3
+        // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|     Version   | Min date time | date1 |    value 1    | date2 |  
+        //+---------------+---------------+-------------------------------+
+        //|     value 2   | date3 |   value  3    | date4 |     value 4   |
+        //+---------------+---------------+-------------------------------+
+
+        public static void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> chunk)
+        {
+            var array = chunk.Array;
+            var offset = chunk.Offset;
+            var count = chunk.Count;
+
+            Array.Sort(array, offset, count, EntryTickComparer.Instance);
+
+            var minDate = array[offset].Ticks;
+
+            outputWriter.Write(Version);
+            outputWriter.Write(minDate);
+
+            for (var i = 0; i < count; i++)
+            {
+                // int allows to write ticks of 7minutes, as reporter runs much more frequent, this can be int
+                var date = (int)(array[offset + i].Ticks - minDate);
+                outputWriter.Write(date);
+                outputWriter.Write(array[offset + i].Value);
+            }
+        }
+
+        class EntryTickComparer : IComparer<RingBuffer.Entry>
+        {
+            public static readonly EntryTickComparer Instance = new EntryTickComparer();
+
+            EntryTickComparer() { }
+
+            public int Compare(RingBuffer.Entry x, RingBuffer.Entry y)
+            {
+                return x.Ticks.CompareTo(y.Ticks);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/RawData/LongValueWriter.cs
+++ b/src/NServiceBus.Metrics/RawData/LongValueWriter.cs
@@ -12,10 +12,10 @@
         // 0                   1                   2                   3
         // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
         //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-        //|     Version   | Min date time | date1 |    value 1    | date2 |  
-        //+---------------+---------------+-------------------------------+
-        //|     value 2   | date3 |   value  3    | date4 |     value 4   |
-        //+---------------+---------------+-------------------------------+
+        //|     Version   | Min date time | count | date1 |     value 1   |
+        //+-------+-------+-------+-------+---------------+-------+-------+
+        //| date2 |   value  2    | date3 |     value 3   | date4 | ...   |
+        //+-------+---------------+-------+---------------+-------+-------+
 
         public static void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> chunk)
         {
@@ -29,6 +29,7 @@
 
             outputWriter.Write(Version);
             outputWriter.Write(minDate);
+            outputWriter.Write(count);
 
             for (var i = 0; i < count; i++)
             {

--- a/src/NServiceBus.Metrics/RawData/OccurrenceWriter.cs
+++ b/src/NServiceBus.Metrics/RawData/OccurrenceWriter.cs
@@ -1,0 +1,42 @@
+namespace NServiceBus.Metrics.RawData
+{
+    using System;
+    using System.IO;
+
+    static class OccurrenceWriter
+    {
+        const long Version = 1;
+
+        // WIRE FORMAT, Version: 1
+
+        //0                   1                   2                   3
+        //0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|     Version   | Base ticks    | date1 | date2 | date3 | date4 |  
+        //+---------------+---------------+-------------------------------+
+        //| date5 | date6 | date7 | date8 | date9 | ...
+        //+---------------+---------------+-------------------------------+
+        //| ....
+
+        public static void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> chunk)
+        {
+            var array = chunk.Array;
+            var offset = chunk.Offset;
+            var count = chunk.Count;
+
+            Array.Sort(array, offset, count, EntryTickComparer.Instance);
+
+            var minDate = array[offset].Ticks;
+
+            outputWriter.Write(Version);
+            outputWriter.Write(minDate);
+
+            for (var i = 0; i < count; i++)
+            {
+                // int allows to write ticks of 7minutes, as reporter runs much more frequent, this can be int
+                var date = (int)(array[offset + i].Ticks - minDate);
+                outputWriter.Write(date);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/RawData/OccurrenceWriter.cs
+++ b/src/NServiceBus.Metrics/RawData/OccurrenceWriter.cs
@@ -12,9 +12,9 @@ namespace NServiceBus.Metrics.RawData
         //0                   1                   2                   3
         //0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
         //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-        //|     Version   | Base ticks    | date1 | date2 | date3 | date4 |  
+        //|     Version   | Base ticks    | count | date1 | date2 | date3 |  
         //+---------------+---------------+-------------------------------+
-        //| date5 | date6 | date7 | date8 | date9 | ...
+        //| date4 | date5 | date6 | date7 | date8 | ...
         //+---------------+---------------+-------------------------------+
         //| ....
 
@@ -30,6 +30,7 @@ namespace NServiceBus.Metrics.RawData
 
             outputWriter.Write(Version);
             outputWriter.Write(minDate);
+            outputWriter.Write(count);
 
             for (var i = 0; i < count; i++)
             {

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -11,32 +11,34 @@
     using Support;
     using Transport;
 
+    delegate void WriteOutput(ArraySegment<RingBuffer.Entry> entries, BinaryWriter outputWriter);
+
     class RawDataReporter
     {
-        public const long Version = 1;
-
         readonly RingBuffer buffer;
+        readonly Action<ArraySegment<RingBuffer.Entry>> outputWriter;
         readonly IDispatchMessages dispatcher;
-        UnicastAddressTag destination;
-        TransportTransaction transportTransaction = new TransportTransaction();
-        Dictionary<string, string> headers = new Dictionary<string, string>();
-        BinaryWriter writer;
-        MemoryStream memoryStream;
-        CancellationTokenSource cancellationTokenSource;
+        readonly UnicastAddressTag destination;
+        readonly TransportTransaction transportTransaction = new TransportTransaction();
+        readonly Dictionary<string, string> headers = new Dictionary<string, string>();
+        readonly BinaryWriter writer;
+        readonly MemoryStream memoryStream;
+        readonly CancellationTokenSource cancellationTokenSource;
         Task reporter;
         static readonly TimeSpan delayTime = TimeSpan.FromSeconds(1);
 
-        public RawDataReporter(IDispatchMessages dispatcher, string destination, HostInformation hostInformation, RingBuffer buffer)
+        public RawDataReporter(IDispatchMessages dispatcher, string destination, HostInformation hostInformation, RingBuffer buffer, string messageTypeName, string endpointName,
+            WriteOutput outputWriter)
         {
             this.buffer = buffer;
+            this.outputWriter = entries=>outputWriter(entries,writer);
             this.dispatcher = dispatcher;
             this.destination = new UnicastAddressTag(destination);
 
             headers[Headers.OriginatingMachine] = RuntimeEnvironment.MachineName;
             headers[Headers.OriginatingHostId] = hostInformation.HostId.ToString("N");
-            headers[Headers.EnclosedMessageTypes] = "NServiceBus.Metrics.RawData"; // without assembly name to allow ducktyping
-            headers[Headers.ContentType] = ContentTypes.Json;
-            headers[Headers.OriginatingEndpoint] = "SOMETHING";
+            headers[Headers.EnclosedMessageTypes] = "NServiceBus.Metrics." + messageTypeName; 
+            headers[Headers.OriginatingEndpoint] = endpointName;
 
             memoryStream = new MemoryStream();
             writer = new BinaryWriter(memoryStream);
@@ -52,7 +54,7 @@
                     // clear stream first
                     memoryStream.SetLength(0);
 
-                    var consumed = buffer.Consume(Consume);
+                    var consumed = buffer.Consume(outputWriter);
 
                     if (consumed == 0)
                     {
@@ -75,51 +77,6 @@
         {
             cancellationTokenSource.Cancel();
             return reporter;
-        }
-
-        void Consume(ArraySegment<RingBuffer.Entry> chunk)
-        {
-            var array = chunk.Array;
-            var offset = chunk.Offset;
-            var count = chunk.Count;
-
-            Array.Sort(array, offset, count, EntryTickComparer.Instance);
-
-            var minDate = array[offset].Ticks;
-
-            // WIRE FORMAT, Version: 1
-
-            // 0                   1                   2                   3
-            // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-            //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-            //|     Version   | Min date time | date1 |    value 1    | date2 |  
-            //+---------------+---------------+-------------------------------+
-            //|     value 2   | date3 |   value  3    | date4 |     value 4   |
-            //+---------------+---------------+-------------------------------+
-            
-
-            writer.Write(Version);
-            writer.Write(minDate);
-
-            for (var i = 0; i < count; i++)
-            {
-                // int allows to write ticks of 7minutes, as reporter runs much more frequent, this can be int
-                var date = (int)(array[offset + i].Ticks - minDate);
-                writer.Write(date);
-                writer.Write(array[offset + i].Value);
-            }
-        }
-
-        class EntryTickComparer : IComparer<RingBuffer.Entry>
-        {
-            public static readonly EntryTickComparer Instance = new EntryTickComparer();
-
-            EntryTickComparer() { }
-
-            public int Compare(RingBuffer.Entry x, RingBuffer.Entry y)
-            {
-                return x.Ticks.CompareTo(y.Ticks);
-            }
         }
     }
 }

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -1,0 +1,125 @@
+﻿namespace NServiceBus.Metrics.RawData
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Hosting;
+    using Routing;
+    using Support;
+    using Transport;
+
+    class RawDataReporter
+    {
+        public const long Version = 1;
+
+        readonly RingBuffer buffer;
+        readonly IDispatchMessages dispatcher;
+        UnicastAddressTag destination;
+        TransportTransaction transportTransaction = new TransportTransaction();
+        Dictionary<string, string> headers = new Dictionary<string, string>();
+        BinaryWriter writer;
+        MemoryStream memoryStream;
+        CancellationTokenSource cancellationTokenSource;
+        Task reporter;
+        static readonly TimeSpan delayTime = TimeSpan.FromSeconds(1);
+
+        public RawDataReporter(IDispatchMessages dispatcher, string destination, HostInformation hostInformation, RingBuffer buffer)
+        {
+            this.buffer = buffer;
+            this.dispatcher = dispatcher;
+            this.destination = new UnicastAddressTag(destination);
+
+            headers[Headers.OriginatingMachine] = RuntimeEnvironment.MachineName;
+            headers[Headers.OriginatingHostId] = hostInformation.HostId.ToString("N");
+            headers[Headers.EnclosedMessageTypes] = "NServiceBus.Metrics.RawData"; // without assembly name to allow ducktyping
+            headers[Headers.ContentType] = ContentTypes.Json;
+            headers[Headers.OriginatingEndpoint] = "SOMETHING";
+
+            memoryStream = new MemoryStream();
+            writer = new BinaryWriter(memoryStream);
+            cancellationTokenSource = new CancellationTokenSource();
+        }
+
+        public void Start()
+        {
+            reporter = Task.Factory.StartNew(async () =>
+            {
+                while (cancellationTokenSource.IsCancellationRequested == false)
+                {
+                    // clear stream first
+                    memoryStream.SetLength(0);
+
+                    var consumed = buffer.Consume(Consume);
+
+                    if (consumed == 0)
+                    {
+                        await Task.Delay(delayTime);
+                    }
+                    else
+                    {
+                        writer.Flush();
+                        var body = memoryStream.ToArray(); // if only transport operation allowed ArraySegment<byte>...
+
+                        var message = new OutgoingMessage(Guid.NewGuid().ToString(), headers, body);
+                        var operation = new TransportOperation(message, destination);
+                        await dispatcher.Dispatch(new TransportOperations(operation), transportTransaction, new ContextBag()).ConfigureAwait(false);
+                    }
+                }
+            });
+        }
+
+        public Task Stop()
+        {
+            cancellationTokenSource.Cancel();
+            return reporter;
+        }
+
+        void Consume(ArraySegment<RingBuffer.Entry> chunk)
+        {
+            var array = chunk.Array;
+            var offset = chunk.Offset;
+            var count = chunk.Count;
+
+            Array.Sort(array, offset, count, EntryTickComparer.Instance);
+
+            var minDate = array[offset].Ticks;
+
+            // WIRE FORMAT, Version: 1
+
+            // 0                   1                   2                   3
+            // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+            //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            //|     Version   | Min date time | date1 |    value 1    | date2 |  
+            //+---------------+---------------+-------------------------------+
+            //|     value 2   | date3 |   value  3    | date4 |     value 4   |
+            //+---------------+---------------+-------------------------------+
+            
+
+            writer.Write(Version);
+            writer.Write(minDate);
+
+            for (var i = 0; i < count; i++)
+            {
+                // int allows to write ticks of 7minutes, as reporter runs much more frequent, this can be int
+                var date = (int)(array[offset + i].Ticks - minDate);
+                writer.Write(date);
+                writer.Write(array[offset + i].Value);
+            }
+        }
+
+        class EntryTickComparer : IComparer<RingBuffer.Entry>
+        {
+            public static readonly EntryTickComparer Instance = new EntryTickComparer();
+
+            EntryTickComparer() { }
+
+            public int Compare(RingBuffer.Entry x, RingBuffer.Entry y)
+            {
+                return x.Ticks.CompareTo(y.Ticks);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -52,6 +52,7 @@
             headers[Headers.OriginatingHostId] = hostInformation.HostId.ToString("N");
             headers[Headers.EnclosedMessageTypes] = "NServiceBus.Metrics." + messageTypeName;
             headers[Headers.OriginatingEndpoint] = endpointName;
+            headers[Headers.ContentType] = "LongValueOccurrence";
 
             memoryStream = new MemoryStream();
             writer = new BinaryWriter(memoryStream);

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -34,12 +34,11 @@
         static readonly TimeSpan singleSpinningTime = TimeSpan.FromMilliseconds(50);
         static ILog log = LogManager.GetLogger<RawDataReporter>();
 
-        public RawDataReporter(IDispatchMessages dispatcher, string destination, HostInformation hostInformation, RingBuffer buffer, string messageTypeName, string endpointName,
-            WriteOutput outputWriter) : this(dispatcher, destination, hostInformation, buffer, messageTypeName, endpointName, outputWriter, DefaultFlushSize, DefaultMaxSpinningTime)
+        public RawDataReporter(IDispatchMessages dispatcher, string destination, Dictionary<string, string> headers, RingBuffer buffer, WriteOutput outputWriter) 
+            : this(dispatcher, destination, headers, buffer, outputWriter, DefaultFlushSize, DefaultMaxSpinningTime)
         { }
 
-        public RawDataReporter(IDispatchMessages dispatcher, string destination, HostInformation hostInformation, RingBuffer buffer, string messageTypeName, string endpointName,
-            WriteOutput outputWriter, int flushSize, TimeSpan maxSpinningTime)
+        public RawDataReporter(IDispatchMessages dispatcher, string destination, Dictionary<string, string> headers, RingBuffer buffer, WriteOutput outputWriter, int flushSize, TimeSpan maxSpinningTime)
         {
             this.buffer = buffer;
             this.flushSize = flushSize;
@@ -47,12 +46,6 @@
             this.outputWriter = entries => outputWriter(entries, writer);
             this.dispatcher = dispatcher;
             this.destination = new UnicastAddressTag(destination);
-
-            headers[Headers.OriginatingMachine] = RuntimeEnvironment.MachineName;
-            headers[Headers.OriginatingHostId] = hostInformation.HostId.ToString("N");
-            headers[Headers.EnclosedMessageTypes] = "NServiceBus.Metrics." + messageTypeName;
-            headers[Headers.OriginatingEndpoint] = endpointName;
-            headers[Headers.ContentType] = "LongValueOccurrence";
 
             memoryStream = new MemoryStream();
             writer = new BinaryWriter(memoryStream);

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -31,6 +31,7 @@
         static readonly TimeSpan DefaultMaxSpinningTime = TimeSpan.FromSeconds(5);
         static readonly TimeSpan singleSpinningTime = TimeSpan.FromMilliseconds(50);
         static ILog log = LogManager.GetLogger<RawDataReporter>();
+        static ContextBag ContextBag = new ContextBag();
 
         public RawDataReporter(IDispatchMessages dispatcher, string destination, Dictionary<string, string> headers, RingBuffer buffer, WriteOutput outputWriter) 
             : this(dispatcher, destination, headers, buffer, outputWriter, DefaultFlushSize, DefaultMaxSpinningTime)
@@ -101,7 +102,7 @@
                 var operation = new TransportOperation(message, destination);
                 try
                 {
-                    await dispatcher.Dispatch(new TransportOperations(operation), transportTransaction, new ContextBag()).ConfigureAwait(false);
+                    await dispatcher.Dispatch(new TransportOperations(operation), transportTransaction, ContextBag).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -14,7 +14,7 @@
 
     delegate void WriteOutput(ArraySegment<RingBuffer.Entry> entries, BinaryWriter outputWriter);
 
-    class RawDataReporter
+    class RawDataReporter : IDisposable
     {
         const int DefaultFlushSize = RingBuffer.Size / 2;
         readonly RingBuffer buffer;
@@ -84,11 +84,11 @@
                         await Task.Delay(singleSpinningTime).ConfigureAwait(false);
                     }
 
-                    await Consume();
+                    await Consume().ConfigureAwait(false);
                 }
 
                 // flush data before ending
-                await Consume();
+                await Consume().ConfigureAwait(false);
             });
         }
 
@@ -121,6 +121,13 @@
         {
             cancellationTokenSource.Cancel();
             return reporter;
+        }
+
+        public void Dispose()
+        {
+            writer?.Dispose();
+            memoryStream?.Dispose();
+            cancellationTokenSource?.Dispose();
         }
     }
 }

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -49,7 +49,7 @@
 
         public void Start()
         {
-            reporter = Task.Factory.StartNew(async () =>
+            reporter = Task.Run(async () =>
             {
                 while (cancellationTokenSource.IsCancellationRequested == false)
                 {
@@ -60,7 +60,7 @@
 
                     if (consumed == 0)
                     {
-                        await Task.Delay(delayTime);
+                        await Task.Delay(delayTime).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -6,10 +6,8 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
-    using Hosting;
     using Logging;
     using Routing;
-    using Support;
     using Transport;
 
     delegate void WriteOutput(ArraySegment<RingBuffer.Entry> entries, BinaryWriter outputWriter);

--- a/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
+++ b/src/NServiceBus.Metrics/RawData/RawDataReporter.cs
@@ -46,6 +46,7 @@
             this.outputWriter = entries => outputWriter(entries, writer);
             this.dispatcher = dispatcher;
             this.destination = new UnicastAddressTag(destination);
+            this.headers = headers;
 
             memoryStream = new MemoryStream();
             writer = new BinaryWriter(memoryStream);

--- a/src/NServiceBus.Metrics/RawData/RingBuffer.cs
+++ b/src/NServiceBus.Metrics/RawData/RingBuffer.cs
@@ -16,6 +16,12 @@
 
         public struct Entry
         {
+            public Entry(long ticks, long value)
+            {
+                Ticks = ticks;
+                Value = value;
+            }
+
             public long Ticks;
             public long Value;
         }
@@ -35,7 +41,11 @@
                     return false;
                 }
                 index = readNextWrite;
+
+                // try to swap nextToWrite
                 readNextWrite = Interlocked.CompareExchange(ref nextToWrite, index + 1, index);
+
+                // do until the swap not succeeded
             } while (index != readNextWrite);
             
             // index is claimed, writing data

--- a/src/NServiceBus.Metrics/RawData/RingBuffer.cs
+++ b/src/NServiceBus.Metrics/RawData/RingBuffer.cs
@@ -64,7 +64,7 @@
         /// <param name="onChunk"></param>
         public int Consume(Action<ArraySegment<Entry>> onChunk)
         {
-            var consume = Interlocked.Read(ref nextToConsume);
+            var consume = Interlocked.CompareExchange(ref nextToConsume, 0, 0);
             var max = Volatile.Read(ref nextToWrite);
 
             var i = consume;

--- a/src/NServiceBus.Metrics/RawData/RingBuffer.cs
+++ b/src/NServiceBus.Metrics/RawData/RingBuffer.cs
@@ -1,0 +1,91 @@
+﻿namespace NServiceBus.Metrics.RawData
+{
+    using System;
+    using System.Threading;
+
+    class RingBuffer
+    {
+        const long Size = 65536;
+        const long SizeMask = Size - 1;
+        const long EpochMask = ~SizeMask;
+
+        long nextToWrite;
+        long nextToConsume;
+
+        Entry[] entries = new Entry[Size];
+
+        public struct Entry
+        {
+            public long Ticks;
+            public long Value;
+        }
+
+        public bool TryWrite(long value)
+        {
+            var write = Interlocked.Increment(ref nextToWrite) - 1;
+            var consume = Volatile.Read(ref nextToConsume);
+
+            if (write - consume > Size)
+            {
+                return false;
+            }
+
+            var i = write & SizeMask;
+            var ticks = DateTime.Now.Ticks;
+
+            entries[i].Value = value;
+            Volatile.Write(ref entries[i].Ticks, ticks);
+
+            return true;
+        }
+        
+        /// <summary>
+        /// Consumes a chunk of entries. This method will call <paramref name="onChunk"/> zero, or one time. No multiple calls will be issued.
+        /// </summary>
+        /// <param name="onChunk"></param>
+        public int Consume(Action<ArraySegment<Entry>> onChunk)
+        {
+            var consume = Interlocked.Read(ref nextToConsume);
+            var max = Volatile.Read(ref nextToWrite);
+
+            var i = consume;
+            while (Volatile.Read(ref entries[i].Ticks) > 0 && i < max)
+            {
+                i++;
+            }
+
+            // [consume, i) - entries to process
+            var indexStart = (int)(consume & SizeMask);
+            var length = (int)(i - consume);
+
+            if (length == 0)
+            {
+                return length;
+            }
+
+            var startEpoch = indexStart & EpochMask;
+            var endEpoch = (indexStart + length) & EpochMask;
+
+            if (startEpoch == endEpoch)
+            {
+                onChunk(new ArraySegment<Entry>(entries, indexStart, length));
+                Array.Clear(entries, indexStart, length);
+            }
+            else
+            {
+                // buffer overlaps
+                var firstEpochEnd = startEpoch + Size - 1;
+                var firstEpochLength = (int)(consume - firstEpochEnd);
+                onChunk(new ArraySegment<Entry>(entries, indexStart, firstEpochLength));
+                Array.Clear(entries, indexStart, firstEpochLength);
+
+                // onChunk is called once per call now
+                //onChunk(new ArraySegment<Entry>(entries, 0, length - firstEpochLength));
+                //Array.Clear(entries, 0, length - firstEpochLength);
+            }
+
+            Interlocked.Add(ref nextToConsume, length);
+            return length;
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/RawData/RingBuffer.cs
+++ b/src/NServiceBus.Metrics/RawData/RingBuffer.cs
@@ -68,6 +68,15 @@
             var max = Volatile.Read(ref nextToWrite);
 
             var i = consume;
+            
+            // The epoch identifies the id of the current passage over the circular buffer. 
+            // This is used to ensure, that once the Consume goes over the edge of the buffer, 
+            // and starts from the beginning, this part won't be included in the result passed to onChunk. 
+            // If it was, this could not be represented as a continuous ArraySegment<Entry>.
+            //
+            // Example:
+            // To consume a buffer with following values [5, 6, null, 4] the consumer would first consume
+            // a segment [4] followed by consumption of [5, 6] in the next Consume call.
             var epoch = i & EpochMask;
             var length = 0;
             while (Volatile.Read(ref entries[i & SizeMask].Ticks) > 0 && i < max)

--- a/src/NServiceBus.Metrics/RawData/RingBuffer.cs
+++ b/src/NServiceBus.Metrics/RawData/RingBuffer.cs
@@ -58,6 +58,11 @@
             return true;
         }
 
+        public long RoughlyEstimateItemsToConsume()
+        {
+            return Volatile.Read(ref nextToWrite) - Volatile.Read(ref nextToConsume);
+        }
+
         // Consumes a chunk of entries. This method will call onChunk zero, or one time. No multiple calls will be issued.
         public int Consume(Action<ArraySegment<Entry>> onChunk)
         {

--- a/src/NServiceBus.Metrics/RawData/RingBuffer.cs
+++ b/src/NServiceBus.Metrics/RawData/RingBuffer.cs
@@ -58,10 +58,7 @@
             return true;
         }
 
-        /// <summary>
-        /// Consumes a chunk of entries. This method will call <paramref name="onChunk"/> zero, or one time. No multiple calls will be issued.
-        /// </summary>
-        /// <param name="onChunk"></param>
+        // Consumes a chunk of entries. This method will call onChunk zero, or one time. No multiple calls will be issued.
         public int Consume(Action<ArraySegment<Entry>> onChunk)
         {
             var consume = Interlocked.CompareExchange(ref nextToConsume, 0, 0);

--- a/src/NServiceBus.Metrics/RawData/Util.cs
+++ b/src/NServiceBus.Metrics/RawData/Util.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.Metrics.RawData
+{
+    using System.Runtime.CompilerServices;
+
+    static class Util
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPowerOfTwo(this int n)
+        {
+            return (n & (n - 1)) == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPowerOfTwo(this long n)
+        {
+            return (n & (n - 1)) == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Log2(this int i)
+        {
+            var r = 0;
+            while ((i >>= 1) != 0)
+            {
+                ++r;
+            }
+            return r;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int Log2(this long i)
+        {
+            var r = 0;
+            while ((i >>= 1) != 0)
+            {
+                ++r;
+            }
+            return r;
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a way of efficient sending lots of data points to `ServiceControl.Monitoring`. It does it by using a ring buffer on the endpoint side, that can record `long` values with their occurrence dates, in a thread-safe manner, without much overhead . Additionally it provides a `RawDataReporter` that can encode data and send them to `SC.Monitoring`. The overall approach is based on following assumptions:

- do not harm endpoints' performance (especially ones with high concurrency)
- as we record every value, let's not allocate that much if not needed
- enable bulk/chunk processing with smart batching (take the whole chunk that was written so far)
- use a custom wire format, to do not dump everything over JSON (this might not work for bigger workloads) and to enable streaming over the message body (on the reader side that might remove allocations)
- version schema (first 8bytes in the raw message are for version which is now set to `Version=1`)

### Wire formats

#### Long values, with occurrence dates

- every value with date is encoded on **only 12 bytes**
- real occurrence date is calculated with `occurrenceDate = dateN + Base ticks`

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|     Version   | Min date time | count | date1 |     value 1   |
+-------+-------+-------+-------+---------------+-------+-------+
| date2 |   value  2    | date3 |     value 3   | date4 | ...   |
+-------+---------------+-------+---------------+-------+-------+

```

#### Occurrences, with no value

- every occurrence has its date encoded on **only 4 bytes**
- real occurrence date is calculated with `occurrenceDate = dateN + Base ticks`

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|     Version   | Base ticks    | count | date1 | date2 | date3 |
+---------------+---------------+-------------------------------+
| date4 | date5 | date6 | date7 | date8 | ...
+---------------+---------------+-------------------------------+
| ....

```
Following improvements could be considered:
- use `log2` for storing values, which for every value guarantees that it's preserved as the clostest 2^n value. This would enable us to store `longs` as `ushort` but with limited accuracy.

