### PR TITLE
Retry occurrence reports send to SC.Monitoring

### DIFF
--- a/src/NServiceBus.Metrics.AcceptanceTests/Tests/QueueLength/When_receiving_message.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/Tests/QueueLength/When_receiving_message.cs
@@ -71,8 +71,6 @@
             }
         }
 
-       
-
         public class TestMessage : ICommand
         {
         }

--- a/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_reporting_to_ServiceControl.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_reporting_to_ServiceControl.cs
@@ -87,7 +87,8 @@
         {
             "# of msgs failures / sec",
             "# of msgs pulled from the input queue /sec",
-            "# of msgs successfully processed / sec"
+            "# of msgs successfully processed / sec",
+            "Retries"
         };
     }
 }

--- a/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_reporting_to_custom_function.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_reporting_to_custom_function.cs
@@ -53,6 +53,7 @@
             "# of msgs failures / sec",
             "# of msgs pulled from the input queue /sec",
             "# of msgs successfully processed / sec",
+            "Retries",
             "Critical Time",
             "Processing Time"
         };

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -8,6 +8,7 @@ using NServiceBus.Features;
 using NServiceBus.Hosting;
 using NServiceBus.Logging;
 using NServiceBus.Metrics;
+using NServiceBus.Metrics.ProbeBuilders;
 using NServiceBus.Metrics.QueueLength;
 using NServiceBus.Metrics.RawData;
 using NServiceBus.ObjectBuilder;
@@ -138,7 +139,8 @@ class MetricsFeature : Feature
         {
             new MessagePulledFromQueueProbeBuilder(performanceDiagnosticsBehavior),
             new MessageProcessingFailureProbeBuilder(performanceDiagnosticsBehavior),
-            new MessageProcessingSuccessProbeBuilder(performanceDiagnosticsBehavior)
+            new MessageProcessingSuccessProbeBuilder(performanceDiagnosticsBehavior),
+            new RetriesProbeBuilder(context)
         };
 
         return new ProbeContext(

--- a/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.Metrics.ProbeBuilders
+{
+    using Features;
+
+    [ProbeProperties("Retries", "A message has been scheduled for retry (FLR or SLR)")]
+    class RetriesProbeBuilder : SignalProbeBuilder
+    {
+        Notifications notifications;
+
+        public RetriesProbeBuilder(FeatureConfigurationContext context)
+        {
+            notifications = context.Settings.Get<Notifications>();
+        }
+
+        protected override void WireUp(SignalProbe probe)
+        {
+            notifications.Errors.MessageHasFailedAnImmediateRetryAttempt += (sender, message) => probe.Signal();
+            notifications.Errors.MessageHasBeenSentToDelayedRetries += (sender, message) => probe.Signal();
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
@@ -2,10 +2,10 @@
 {
     using Features;
 
-    [ProbeProperties("Retries", "A message has been scheduled for retry (FLR or SLR)")]
+    [ProbeProperties(Retries, "A message has been scheduled for retry (FLR or SLR)")]
     class RetriesProbeBuilder : SignalProbeBuilder
     {
-        Notifications notifications;
+        public const string Retries = "Retries";
 
         public RetriesProbeBuilder(FeatureConfigurationContext context)
         {
@@ -17,5 +17,7 @@
             notifications.Errors.MessageHasFailedAnImmediateRetryAttempt += (sender, message) => probe.Signal();
             notifications.Errors.MessageHasBeenSentToDelayedRetries += (sender, message) => probe.Signal();
         }
+
+        readonly Notifications notifications;
     }
 }

--- a/src/SampleEndpoint/SomeCommandHandler.cs
+++ b/src/SampleEndpoint/SomeCommandHandler.cs
@@ -6,6 +6,8 @@ class SomeCommandHandler : IHandleMessages<SomeCommand>
 {
     public Task Handle(SomeCommand message, IMessageHandlerContext context)
     {
-        return Task.Delay(TimeSpan.FromSeconds(2));
+        throw new Exception("boom!");
+
+        //return Task.Delay(TimeSpan.FromSeconds(2));
     } 
 }


### PR DESCRIPTION
## Description
This PR introduces following changes:
  * New `ISingalProbe` named Retries that signals FLR or SLR occurrence,
  * New Occurence report sent to `SC.Monitoring` that stores information about retry occurrences

/cc: @Scooletz @WojcikMike 