### PR TITLE
[WIP] Introducing probe id

### DIFF
--- a/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
@@ -3,9 +3,10 @@ using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Metrics;
 
-[ProbeProperties(CriticalTime, "The time it took from sending to processing the message.")]
+[ProbeProperties(CriticalTimeId, CriticalTime, "The time it took from sending to processing the message.")]
 class CriticalTimeProbeBuilder : DurationProbeBuilder
 {
+    public const string CriticalTimeId = "nservicebus_criticaltime_seconds";
     public const string CriticalTime = "Critical Time";
 
     public CriticalTimeProbeBuilder(FeatureConfigurationContext context)

--- a/src/NServiceBus.Metrics/ProbeBuilders/MessageProcessingFailureProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/MessageProcessingFailureProbeBuilder.cs
@@ -1,4 +1,4 @@
-[ProbeProperties("# of msgs failures / sec", "The current number of failed processed messages by the transport per second.")]
+[ProbeProperties("nservicebus_failure_total", "# of msgs failures / sec", "The current number of failed processed messages by the transport per second.")]
 class MessageProcessingFailureProbeBuilder : SignalProbeBuilder
 {
     public MessageProcessingFailureProbeBuilder(ReceivePerformanceDiagnosticsBehavior behavior)

--- a/src/NServiceBus.Metrics/ProbeBuilders/MessageProcessingSuccessProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/MessageProcessingSuccessProbeBuilder.cs
@@ -1,4 +1,4 @@
-[ProbeProperties("# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.")]
+[ProbeProperties("nservicebus_success_total", "# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.")]
 class MessageProcessingSuccessProbeBuilder : SignalProbeBuilder
 {
     public MessageProcessingSuccessProbeBuilder(ReceivePerformanceDiagnosticsBehavior behavior)

--- a/src/NServiceBus.Metrics/ProbeBuilders/MessagePulledFromQueueProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/MessagePulledFromQueueProbeBuilder.cs
@@ -1,4 +1,4 @@
-[ProbeProperties("# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.")]
+[ProbeProperties("nservicebus_fetched_total", "# of msgs pulled from the input queue /sec", "The current number of messages pulled from the input queue by the transport per second.")]
 class MessagePulledFromQueueProbeBuilder : SignalProbeBuilder
 {
     public MessagePulledFromQueueProbeBuilder(ReceivePerformanceDiagnosticsBehavior behavior)

--- a/src/NServiceBus.Metrics/ProbeBuilders/ProbePropertiesAttribute.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ProbePropertiesAttribute.cs
@@ -2,13 +2,15 @@ using System;
 
 [AttributeUsage(AttributeTargets.Class)]
 sealed class ProbePropertiesAttribute : Attribute
-{
-    public ProbePropertiesAttribute(string name, string description)
+{  
+    public ProbePropertiesAttribute(string id, string name, string description)
     {
+        Id = id;
         Name = name;
         Description = description;
     }
 
+    public readonly string Id;
     public readonly string Name;
     public readonly string Description;
 }

--- a/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
@@ -2,7 +2,7 @@ using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Metrics;
 
-[ProbeProperties(ProcessingTime, "The time it took to successfully process a message.")]
+[ProbeProperties(ProcessingTimeId, ProcessingTime, "The time it took to successfully process a message.")]
 class ProcessingTimeProbeBuilder : DurationProbeBuilder
 {
     public ProcessingTimeProbeBuilder(FeatureConfigurationContext context)
@@ -27,5 +27,6 @@ class ProcessingTimeProbeBuilder : DurationProbeBuilder
     
     readonly FeatureConfigurationContext context;
 
+    public const string ProcessingTimeId = "nservicebus_processingtime_seconds";
     public const string ProcessingTime = "Processing Time";
 }

--- a/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
@@ -2,10 +2,11 @@
 {
     using Features;
 
-    [ProbeProperties(Retries, "A message has been scheduled for retry (FLR or SLR)")]
+    [ProbeProperties(RetriesId, Retries, "A message has been scheduled for retry (FLR or SLR)")]
     class RetriesProbeBuilder : SignalProbeBuilder
     {
         public const string Retries = "Retries";
+        public const string RetriesId = "nservicebus_retries_total";
 
         public RetriesProbeBuilder(FeatureConfigurationContext context)
         {


### PR DESCRIPTION
Because of legacy reasons we introduced the probe name which contains a very verbose string to name the probe which is then later used to be turned into a performance counter. This PR introduces a stable short ID which can be used to uniquely identify probes in a meaningful way. Then we could reduce the mapping logics in downstream drastically. 

This would be a breaking change as far as the perf counters script generation is concerned but I'm not too worried about that since we can up the nuspec dependency to the version that has this merged. 

Thoughts @Particular/metrics-maintainers ?