### PR TITLE
[Spike] Metrics in v5

### DIFF
--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Metrics.NET" Version="0.4.8" />
-    <PackageReference Include="NServiceBus" Version="6.2.0" />
+    <PackageReference Include="NServiceBus" Version="5.2.22" />
     <PackageReference Include="NuGetPackager" Version="0.6.3" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.2" />

--- a/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
@@ -15,7 +15,9 @@ class CriticalTimeProbeBuilder : DurationProbeBuilder
 
     protected override void WireUp(DurationProbe probe)
     {
-        context.Pipeline.OnReceivePipelineCompleted(e =>
+        // CriticalTimeBehavior
+        
+        context.Pipeline. OnReceivePipelineCompleted(e =>
         {
             DateTime timeSent;
             if (e.TryGetTimeSent(out timeSent))

--- a/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
@@ -12,6 +12,8 @@ class ProcessingTimeProbeBuilder : DurationProbeBuilder
 
     protected override void WireUp(DurationProbe probe)
     {
+        // Processing statistics behavior
+        
         context.Pipeline.OnReceivePipelineCompleted(e =>
         {
             string messageTypeProcessed;

--- a/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs
@@ -2,6 +2,8 @@
 using System.Threading.Tasks;
 using NServiceBus.Pipeline;
 
+// as a first behavior
+
 class ReceivePerformanceDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
 {
     public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)

--- a/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
@@ -14,6 +14,8 @@
 
         protected override void WireUp(SignalProbe probe)
         {
+            // NServiceBus.Faults.ErrorsNotifications
+
             notifications.Errors.MessageHasFailedAnImmediateRetryAttempt += (sender, message) => probe.Signal();
             notifications.Errors.MessageHasBeenSentToDelayedRetries += (sender, message) => probe.Signal();
         }


### PR DESCRIPTION
This PR provides a spike for Metrics aligned to the core v5. Following points were / need to be addressed:

- feature startup tasks: v5 provides only the way to register a startup task type, not the instance. This requires changing ctors, to accept all the required parameters
- `IDispatchMessages` -> `ISendMessages`: v5 uses ISendMessages to send raw messages
- no `Task`s for startup tasks: the way to implement all asynchronicity is to spawn a thread. Reporters were rewritten in that way already
- lack of `context.Pipeline.OnReceivePipelineCompleted` used for both `ProcessingTimeProbe` and `CriticalTimeProbe`: in v5 this should be done via behavior as there are no notification one can register to
- `RetriesProbe`: in the current package is based on `context.Settings.Get<Notifications>.Errors` which is not available in v5. There is a way to register to the retries, but as it copies whole content, this should be reevaluated.

**Summing up:**
There's some work that need to be done. I think we could easily follow 80/20 rule, providing majority of the features in v5 within reasonable time boundaries, leaving things like `Retries` for the desert.