### PR TITLE
Attach metrics' instance id to every message

### DIFF
--- a/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_sending_regular_message.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_sending_regular_message.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.Metrics.AcceptanceTests.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_regular_message : NServiceBusAcceptanceTest
+    {
+        const string InstanceId = "Metrics_instance_id_value";
+
+        [Test]
+        public async Task Should_include_metrics_custom_instance_id_as_a_header()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b=>b.When(c=>c.Send(Conventions.EndpointNamingConvention(typeof(Receiver)), new Message())))
+                .WithEndpoint<Receiver>()
+                .Done(c=>c.NServiceBus_Metric_InstanceId_Header_Value == InstanceId)
+                .Run()
+                .ConfigureAwait(false);
+
+            Assert.AreEqual(InstanceId, context.NServiceBus_Metric_InstanceId_Header_Value);
+        }
+
+        class Context : ScenarioContext
+        {
+            public string NServiceBus_Metric_InstanceId_Header_Value;
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var metrics = c.EnableMetrics();
+#pragma warning disable 618
+                    metrics.SendMetricDataToServiceControl("non-existing-queue", TimeSpan.FromSeconds(1), InstanceId);
+#pragma warning restore 618
+                });
+            }
+        }
+
+        class Message : IMessage
+        {
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                }).IncludeType<Message>();
+            }
+
+            public class MessageHandler : IHandleMessages<Message>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    string header;
+                    context.MessageHeaders.TryGetValue("NServiceBus.Metric.InstanceId", out header);
+
+                    TestContext.NServiceBus_Metric_InstanceId_Header_Value = header;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_sending_regular_message.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_sending_regular_message.cs
@@ -44,7 +44,7 @@
             }
         }
 
-        class Message : IMessage
+        public class Message : IMessage
         {
         }
 

--- a/src/NServiceBus.Metrics/MetricsOptions.cs
+++ b/src/NServiceBus.Metrics/MetricsOptions.cs
@@ -74,7 +74,7 @@
 
             ServiceControlMetricsAddress = serviceControlMetricsAddress;
             ServiceControlReportingInterval = interval;
-            EndpointInstanceIdOverride = instanceId;
+            endpointInstanceIdOverride = instanceId;
         }
 
         /// <summary>
@@ -100,7 +100,19 @@
 
         internal string ServiceControlMetricsAddress;
         internal TimeSpan ServiceControlReportingInterval;
-        internal string EndpointInstanceIdOverride;
+        string endpointInstanceIdOverride;
+
+        internal bool TryGetValidEndpointInstanceIdOverride(out string instanceId)
+        {
+            if (string.IsNullOrEmpty(endpointInstanceIdOverride) == false)
+            {
+                instanceId = endpointInstanceIdOverride;
+                return true;
+            }
+
+            instanceId = null;
+            return false;
+        }
 
         Action<ProbeContext> registerObservers = c => {};
 


### PR DESCRIPTION
This PR introduces a message mutator that adds the header `NServiceBus.Metric.InstanceId` with the user-assigned metrics` id value.

### Details
As requested in #42, there are occasions where it would be beneficial to correlate a regular message with an endpoints instance on the basis of the user-assigned metrics' instance id. 