### PR TITLE
Tagged value writer

### DIFF
--- a/src/NServiceBus.Metrics.Tests/RawData/TaggedLongValueWriterTests.cs
+++ b/src/NServiceBus.Metrics.Tests/RawData/TaggedLongValueWriterTests.cs
@@ -1,0 +1,137 @@
+﻿namespace NServiceBus.Metrics.Tests.RawData
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using Metrics.RawData;
+    using NUnit.Framework;
+
+    public class TaggedLongValueWriterTests : WriterTestBase
+    {
+        static readonly UTF8Encoding NoBom = new UTF8Encoding(false);
+
+        public TaggedLongValueWriterTests() 
+            : base(Write)
+        {
+        }
+
+        [Test]
+        public void Writing_one_not_tagged_value()
+        {
+            const long version = 1L;
+            const long ticks = 2;
+            const long value = 3;
+
+            var entry = new RingBuffer.Entry { Ticks = ticks, Value = value };
+            Write(entry);
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+                writer.Write(0); // tag count
+                writer.Write(1); // entry count
+                writer.Write(0);
+                writer.Write(value);
+            });
+        }
+
+        [Test]
+        public void Writing_one_tagged_value()
+        {
+            const long version = 1L;
+            const long ticks = 13123;
+            const long value = 1345347;
+
+            const string tagName = "this is a test tag value 111!!!";
+            var tagId = Writer.GetTagId(tagName);
+            var bytes = NoBom.GetBytes(tagName);
+
+            var entry = new RingBuffer.Entry { Ticks = ticks, Value = value, Tag = tagId };
+            Write(entry);
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+
+                writer.Write(1); // tag count
+
+                // tag entry
+                writer.Write(tagId);
+                writer.Write(bytes.Length);
+                writer.Write(bytes);
+
+                writer.Write(1); // entry count
+                writer.Write(0);
+                writer.Write(value);
+            });
+        }
+
+        [Test]
+        public void Writing_two_tagged_values_sorted_by_date()
+        {
+            const long version = 1L;
+            const long ticks = 334346347;
+            const long value1 = 983745897384573;
+            const long value2 = value1 + 1;
+            const int timeDiff = 1;
+
+            const string tagName1 = "this is a test tag value 111!!!";
+            var tagId1 = Writer.GetTagId(tagName1);
+            var bytes1 = NoBom.GetBytes(tagName1);
+
+            const string tagName2 = "this is another test tag value 222@@@ Even longer than the first one!";
+            var tagId2 = Writer.GetTagId(tagName2);
+            var bytes2 = NoBom.GetBytes(tagName2);
+
+            Write(
+                new RingBuffer.Entry(ticks + timeDiff, value2, tagId2),
+                new RingBuffer.Entry(ticks, value1, tagId1)
+            );
+
+            Assert(writer =>
+            {
+                writer.Write(version);
+                writer.Write(ticks);
+
+                writer.Write(2); // tag count
+
+                // tag1
+                writer.Write(tagId1);
+                writer.Write(bytes1.Length);
+                writer.Write(bytes1); 
+                
+                // tag2
+                writer.Write(tagId2);
+                writer.Write(bytes2.Length);
+                writer.Write(bytes2);
+
+                writer.Write(2);
+                writer.Write(0);
+                writer.Write(value1);
+                writer.Write(timeDiff);
+                writer.Write(value2);
+            });
+        }
+
+
+
+        [SetUp]
+        public new void SetUp()
+        {
+             Writer = new TaggedLongValueWriter();
+        }
+
+        static void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> entries)
+        {
+            Writer.Write(outputWriter, entries);
+        }
+
+        static TaggedLongValueWriter Writer
+        {
+            get { return (TaggedLongValueWriter) TestContext.CurrentContext.Test.Properties.Get(nameof(TaggedLongValueWriter)); }
+            set { TestContext.CurrentContext.Test.Properties.Set(nameof(TaggedLongValueWriter), value);}
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/RawData/RingBuffer.cs
+++ b/src/NServiceBus.Metrics/RawData/RingBuffer.cs
@@ -16,17 +16,19 @@
 
         public struct Entry
         {
-            public Entry(long ticks, long value)
+            public Entry(long ticks, long value, int tag = 0)
             {
                 Ticks = ticks;
                 Value = value;
+                Tag = tag;
             }
 
             public long Ticks;
             public long Value;
+            public int Tag;
         }
 
-        public bool TryWrite(long value)
+        public bool TryWrite(long value, int tag = 0)
         {
             var readNextWrite = Volatile.Read(ref nextToWrite);
             long index;
@@ -53,6 +55,8 @@
             var ticks = DateTime.UtcNow.Ticks;
 
             entries[i].Value = value;
+            entries[i].Tag = tag;
+
             Volatile.Write(ref entries[i].Ticks, ticks);
 
             return true;

--- a/src/NServiceBus.Metrics/RawData/TaggedLongValueWriter.cs
+++ b/src/NServiceBus.Metrics/RawData/TaggedLongValueWriter.cs
@@ -1,0 +1,109 @@
+﻿namespace NServiceBus.Metrics.RawData
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using System.Threading;
+
+    /// <summary>
+    /// This writer provides a protocol for writing string-tagged values.
+    /// The tags are written as a dictionary at the beginning of the payload, which enables reading it to a local dictionary and performing a fast transformation for the reader.
+    /// </summary>
+    class TaggedLongValueWriter
+    {
+        const long Version = 1;
+
+        static readonly UTF8Encoding NoBom = new UTF8Encoding(false);
+        readonly ConcurrentDictionary<string, Tag> byTagName = new ConcurrentDictionary<string, Tag>();
+        readonly ConcurrentDictionary<int, Tag> byTagId = new ConcurrentDictionary<int, Tag>();
+        readonly Func<string, Tag> GenerateTag;
+        int generator;
+
+        public TaggedLongValueWriter()
+        {
+            GenerateTag = str =>
+            {
+                var id = Interlocked.Increment(ref generator);
+                var tag = new Tag(str, id);
+                byTagId[id] = tag;
+                return tag;
+            };
+        }
+
+        // WIRE FORMAT, Version: 1
+
+        // 0                   1                   2                   3
+        // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+        //+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+        //|     Version   | Min date time |tag cnt|tag1key|tag1len| tag1..|
+        //+-------+-------+-------+-------+---------------+-------+-------+
+        //| ..bytes       |tag2key|tag2len| tag2 bytes .................  |
+        //+-------+-------+-------+-------+---------------+-------+-------+
+        //| tag2 bytes continued                  | count | date1 | tag1  |
+        //+-------+-------+-------+-------+---------------+-------+-------+
+        //|    value 1    | date2 | tag2  |     value 2   | date3 | ...   |
+        //+-------+---------------+-------+---------------+-------+-------+
+        public void Write(BinaryWriter outputWriter, ArraySegment<RingBuffer.Entry> chunk)
+        {
+            var array = chunk.Array;
+            var offset = chunk.Offset;
+            var count = chunk.Count;
+
+            Array.Sort(array, offset, count, EntryTickComparer.Instance);
+
+            var minDate = array[offset].Ticks;
+
+            outputWriter.Write(Version);
+            outputWriter.Write(minDate);
+
+            WriteTags(outputWriter, count, array, offset);
+
+            outputWriter.Write(count);
+
+            for (var i = 0; i < count; i++)
+            {
+                // int allows to write ticks of 7minutes, as reporter runs much more frequent, this can be int
+                var date = (int)(array[offset + i].Ticks - minDate);
+                outputWriter.Write(date);
+                outputWriter.Write(array[offset + i].Value);
+            }
+        }
+
+        void WriteTags(BinaryWriter outputWriter, int count, RingBuffer.Entry[] array, int offset)
+        {
+            var tags = new Dictionary<int, Tag>();
+            for (var i = 0; i < count; i++)
+            {
+                var tag = array[offset + i].Tag;
+                if (tag > 0 && tags.ContainsKey(tag) == false)
+                {
+                    tags[tag] = byTagId[tag];
+                }
+            }
+
+            outputWriter.Write(tags.Count);
+            foreach (var tag in tags)
+            {
+                outputWriter.Write(tag.Key);
+                outputWriter.Write(tag.Value.Bytes.Length);
+                outputWriter.Write(tag.Value.Bytes);
+            }
+        }
+
+        public int GetTagId(string tagName) => byTagName.GetOrAdd(tagName, GenerateTag).ID;
+
+        class Tag
+        {
+            public Tag(string tag, int id)
+            {
+                ID = id;
+                Bytes = NoBom.GetBytes(tag);
+            }
+
+            public int ID { get; }
+            public byte[] Bytes { get; }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a tagged value writer. This is a writer that enables registering `long` values with dates of their occurrences, additionally tagging them with a custom `string` tag. This could be useful to include a message type, or any other tag for a reported value.

The wire format of this writer provides following properties:
- tags' string values are written once and encoded as `(int)->(string)` map
- tags are written at the beginning, allowing reader to decode them and map all the values read after it
- `(date, value, tag)` are encoded on 16 bytes: date(4), value(8), tag(4)
- tags encoding does not require maintaining a session. In other words, every message is self-descriptive and self-contained
- tags are encoded only once. `byte[]` being a result of encoding are kept for later reuse