### PR TITLE
Probes' notifications as events

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 assembly-versioning-scheme: Major
-next-version: 1.0.0
+next-version: 2.0.0
 commit-message-incrementing: Disabled
 branches:
   develop:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 assembly-versioning-scheme: Major
-next-version: 2.0.0
+next-version: 1.0.0
 commit-message-incrementing: Disabled
 branches:
   develop:

--- a/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
+++ b/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
@@ -5,6 +5,9 @@
     <DebugSymbols>True</DebugSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>7</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="1.1.0" />

--- a/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
+++ b/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
@@ -9,6 +9,9 @@
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>7</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="NServiceBus.Metrics.approved.cs" />
     <Compile Remove="NServiceBus.Metrics.received.cs" />

--- a/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.approved.cs
+++ b/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.approved.cs
@@ -5,9 +5,15 @@
 namespace NServiceBus
 {
     
+    public struct DurationEvent
+    {
+        public readonly System.TimeSpan Duration;
+        public readonly string MessageType;
+        public DurationEvent(System.TimeSpan duration, string messageType) { }
+    }
     public interface IDurationProbe : NServiceBus.IProbe
     {
-        void Register(System.Action<System.TimeSpan> observer);
+        void Register(NServiceBus.OnEvent<NServiceBus.DurationEvent> observer);
     }
     public interface IProbe
     {
@@ -16,7 +22,7 @@ namespace NServiceBus
     }
     public interface ISignalProbe : NServiceBus.IProbe
     {
-        void Register(System.Action observer);
+        void Register(NServiceBus.OnEvent<NServiceBus.SignalEvent> observer);
     }
     public class static MetricsConfigurationExtensions
     {
@@ -40,10 +46,16 @@ namespace NServiceBus
             "ed in version 3.0.0.", false)]
         public void SendMetricDataToServiceControl(string serviceControlMetricsAddress, System.TimeSpan interval, string instanceId = null) { }
     }
+    public delegate void OnEvent<TEventType>(ref TEventType e);
     public class ProbeContext
     {
         public ProbeContext(System.Collections.Generic.IReadOnlyCollection<NServiceBus.IDurationProbe> durations, System.Collections.Generic.IReadOnlyCollection<NServiceBus.ISignalProbe> signals) { }
         public System.Collections.Generic.IReadOnlyCollection<NServiceBus.IDurationProbe> Durations { get; }
         public System.Collections.Generic.IReadOnlyCollection<NServiceBus.ISignalProbe> Signals { get; }
+    }
+    public struct SignalEvent
+    {
+        public readonly string MessageType;
+        public SignalEvent(string messageType) { }
     }
 }

--- a/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.approved.cs
+++ b/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.approved.cs
@@ -14,6 +14,8 @@ namespace NServiceBus
     public interface IDurationProbe : NServiceBus.IProbe
     {
         void Register(NServiceBus.OnEvent<NServiceBus.DurationEvent> observer);
+        [System.ObsoleteAttribute("Use Register with a DurationEvent instead. Will be removed in version 2.0.0.", true)]
+        void Register(System.Action<System.TimeSpan> observer);
     }
     public interface IProbe
     {
@@ -23,6 +25,8 @@ namespace NServiceBus
     public interface ISignalProbe : NServiceBus.IProbe
     {
         void Register(NServiceBus.OnEvent<NServiceBus.SignalEvent> observer);
+        [System.ObsoleteAttribute("Use Register with a DurationEvent instead. Will be removed in version 2.0.0.", true)]
+        void Register(System.Action observer);
     }
     public class static MetricsConfigurationExtensions
     {

--- a/src/NServiceBus.Metrics.sln.DotSettings
+++ b/src/NServiceBus.Metrics.sln.DotSettings
@@ -1,6 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp70</s:String>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/AutoCompleteBasicCompletion/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/LookupWindow/ShowSummary/@EntryValue">True</s:Boolean>

--- a/src/NServiceBus.Metrics/Extensions.cs
+++ b/src/NServiceBus.Metrics/Extensions.cs
@@ -8,8 +8,7 @@ static class Extensions
     public static bool TryGetTimeSent(this ReceivePipelineCompleted completed, out DateTime timeSent)
     {
         var headers = completed.ProcessedMessage.Headers;
-        string timeSentString;
-        if (headers.TryGetValue(Headers.TimeSent, out timeSentString))
+        if (headers.TryGetValue(Headers.TimeSent, out string timeSentString))
         {
             timeSent = DateTimeExtensions.ToUtcDateTime(timeSentString);
             return true;
@@ -18,15 +17,14 @@ static class Extensions
         return false;
     }
 
-    public static bool TryGetMessageType(this ReceivePipelineCompleted completed, out string ProcessedMessageType)
+    public static bool TryGetMessageType(this ReceivePipelineCompleted completed, out string processedMessageType)
     {
-        return completed.ProcessedMessage.Headers.TryGetMessageType(out ProcessedMessageType);
+        return completed.ProcessedMessage.Headers.TryGetMessageType(out processedMessageType);
     }
 
-    public static bool TryGetMessageType(this IReadOnlyDictionary<string, string> headers, out string processedMessageType)
+    internal static bool TryGetMessageType(this IReadOnlyDictionary<string, string> headers, out string processedMessageType)
     {
-        string enclosedMessageType;
-        if (headers.TryGetValue(Headers.EnclosedMessageTypes, out enclosedMessageType))
+        if (headers.TryGetValue(Headers.EnclosedMessageTypes, out string enclosedMessageType))
         {
             processedMessageType = enclosedMessageType;
             return true;

--- a/src/NServiceBus.Metrics/Extensions.cs
+++ b/src/NServiceBus.Metrics/Extensions.cs
@@ -29,7 +29,7 @@ static class Extensions
             processedMessageType = enclosedMessageType;
             return true;
         }
-        processedMessageType = "Undefined";
+        processedMessageType = null;
         return false;
     }
 

--- a/src/NServiceBus.Metrics/Extensions.cs
+++ b/src/NServiceBus.Metrics/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NServiceBus;
 using NServiceBus.Features;
 
@@ -19,14 +20,18 @@ static class Extensions
 
     public static bool TryGetMessageType(this ReceivePipelineCompleted completed, out string ProcessedMessageType)
     {
-        var headers = completed.ProcessedMessage.Headers;
+        return completed.ProcessedMessage.Headers.TryGetMessageType(out ProcessedMessageType);
+    }
+
+    public static bool TryGetMessageType(this IReadOnlyDictionary<string, string> headers, out string processedMessageType)
+    {
         string enclosedMessageType;
         if (headers.TryGetValue(Headers.EnclosedMessageTypes, out enclosedMessageType))
         {
-            ProcessedMessageType = enclosedMessageType;
+            processedMessageType = enclosedMessageType;
             return true;
         }
-        ProcessedMessageType = "Undefined";
+        processedMessageType = "Undefined";
         return false;
     }
 

--- a/src/NServiceBus.Metrics/Extensions.cs
+++ b/src/NServiceBus.Metrics/Extensions.cs
@@ -8,7 +8,7 @@ static class Extensions
     public static bool TryGetTimeSent(this ReceivePipelineCompleted completed, out DateTime timeSent)
     {
         var headers = completed.ProcessedMessage.Headers;
-        if (headers.TryGetValue(Headers.TimeSent, out string timeSentString))
+        if (headers.TryGetValue(Headers.TimeSent, out var timeSentString))
         {
             timeSent = DateTimeExtensions.ToUtcDateTime(timeSentString);
             return true;
@@ -24,7 +24,7 @@ static class Extensions
 
     internal static bool TryGetMessageType(this IReadOnlyDictionary<string, string> headers, out string processedMessageType)
     {
-        if (headers.TryGetValue(Headers.EnclosedMessageTypes, out string enclosedMessageType))
+        if (headers.TryGetValue(Headers.EnclosedMessageTypes, out var enclosedMessageType))
         {
             processedMessageType = enclosedMessageType;
             return true;

--- a/src/NServiceBus.Metrics/IDurationProbe.cs
+++ b/src/NServiceBus.Metrics/IDurationProbe.cs
@@ -10,7 +10,31 @@ namespace NServiceBus
         /// <summary>
         /// Enables registering action called on event occurrence.
         /// </summary>
-        void Register(Action<TimeSpan> observer);
+        void Register(OnEvent<DurationEvent> observer);
+    }
 
+    /// <summary>
+    /// Provides data for a single recorded duration.
+    /// </summary>
+    public struct DurationEvent
+    {
+        /// <summary>
+        /// Creates the duration event.
+        /// </summary>
+        public DurationEvent(TimeSpan duration, string messageType)
+        {
+            Duration = duration;
+            MessageType = messageType;
+        }
+
+        /// <summary>
+        /// The duration value.
+        /// </summary>
+        public readonly TimeSpan Duration;
+
+        /// <summary>
+        /// The message type, the duration was recorded for, if any.
+        /// </summary>
+        public readonly string MessageType;
     }
 }

--- a/src/NServiceBus.Metrics/IDurationProbe.cs
+++ b/src/NServiceBus.Metrics/IDurationProbe.cs
@@ -41,6 +41,7 @@ namespace NServiceBus
         /// <summary>
         /// The message type, the duration was recorded for, if any.
         /// </summary>
+        // ReSharper disable once NotAccessedField.Global
         public readonly string MessageType;
     }
 }

--- a/src/NServiceBus.Metrics/IDurationProbe.cs
+++ b/src/NServiceBus.Metrics/IDurationProbe.cs
@@ -11,6 +11,12 @@ namespace NServiceBus
         /// Enables registering action called on event occurrence.
         /// </summary>
         void Register(OnEvent<DurationEvent> observer);
+
+        /// <summary>
+        /// Enables registering action called on event occurrence.
+        /// </summary>
+        [ObsoleteEx(Message = "Use Register with a DurationEvent instead", RemoveInVersion = "2.0.0")]
+        void Register(Action<TimeSpan> observer);
     }
 
     /// <summary>

--- a/src/NServiceBus.Metrics/ISignalProbe.cs
+++ b/src/NServiceBus.Metrics/ISignalProbe.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus
 {
+    using System;
+
     /// <summary>
     /// Probe that signals event occurrence
     /// </summary>
@@ -9,6 +11,12 @@
         /// Enables registering action called on event occurrence.
         /// </summary>
         void Register(OnEvent<SignalEvent> observer);
+
+        /// <summary>
+        /// Enables registering action called on event occurrence.
+        /// </summary>
+        [ObsoleteEx(Message = "Use Register with a DurationEvent instead", RemoveInVersion = "2.0.0")]
+        void Register(Action observer);
     }
 
     /// <summary>

--- a/src/NServiceBus.Metrics/ISignalProbe.cs
+++ b/src/NServiceBus.Metrics/ISignalProbe.cs
@@ -35,6 +35,7 @@
         /// <summary>
         /// The message type, the duration was recorded for, if any.
         /// </summary>
+        // ReSharper disable once NotAccessedField.Global
         public readonly string MessageType;
     }
 }

--- a/src/NServiceBus.Metrics/ISignalProbe.cs
+++ b/src/NServiceBus.Metrics/ISignalProbe.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using System;
-
     /// <summary>
     /// Probe that signals event occurrence
     /// </summary>
@@ -10,6 +8,25 @@
         /// <summary>
         /// Enables registering action called on event occurrence.
         /// </summary>
-        void Register(Action observer);
+        void Register(OnEvent<SignalEvent> observer);
+    }
+
+    /// <summary>
+    /// Provides data for a single occurrence of a signal.
+    /// </summary>
+    public struct SignalEvent
+    {
+        /// <summary>
+        /// Creates the signal event.
+        /// </summary>
+        public SignalEvent(string messageType)
+        {
+            MessageType = messageType;
+        }
+
+        /// <summary>
+        /// The message type, the duration was recorded for, if any.
+        /// </summary>
+        public readonly string MessageType;
     }
 }

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -13,6 +13,9 @@
     <NoWarn>CS8002</NoWarn>
     <UpdateAssemblyInfo>true</UpdateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>7</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\packaging\nuget\NServiceBus.Metrics.nuspec" Link="NServiceBus.Metrics.nuspec" />
   </ItemGroup>

--- a/src/NServiceBus.Metrics/OnEvent.cs
+++ b/src/NServiceBus.Metrics/OnEvent.cs
@@ -1,0 +1,9 @@
+﻿namespace NServiceBus
+{
+    /// <summary>
+    /// Represents an action taken when an event <paramref name="e"/> occurs.
+    /// </summary>
+    /// <typeparam name="TEventType">Event type</typeparam>
+    /// <param name="e">The event.</param>
+    public delegate void OnEvent<TEventType>(ref TEventType e);
+}

--- a/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
@@ -21,7 +21,7 @@ class CriticalTimeProbeBuilder : DurationProbeBuilder
             if (e.TryGetTimeSent(out timeSent))
             {
                 var endToEndTime = e.CompletedAt - timeSent;
-                e.TryGetMessageType(out string messageType);
+                e.TryGetMessageType(out var messageType);
 
                 var @event = new DurationEvent(endToEndTime, messageType);
                 probe.Record(ref @event);

--- a/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
@@ -21,8 +21,7 @@ class CriticalTimeProbeBuilder : DurationProbeBuilder
             if (e.TryGetTimeSent(out timeSent))
             {
                 var endToEndTime = e.CompletedAt - timeSent;
-                string messageType;
-                e.TryGetMessageType(out messageType);
+                e.TryGetMessageType(out string messageType);
 
                 var @event = new DurationEvent(endToEndTime, messageType);
                 probe.Record(ref @event);

--- a/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
@@ -21,8 +21,11 @@ class CriticalTimeProbeBuilder : DurationProbeBuilder
             if (e.TryGetTimeSent(out timeSent))
             {
                 var endToEndTime = e.CompletedAt - timeSent;
+                string messageType;
+                e.TryGetMessageType(out messageType);
 
-                probe.Record(endToEndTime);
+                var @event = new DurationEvent(endToEndTime, messageType);
+                probe.Record(ref @event);
             }
 
             return TaskExtensions.Completed;

--- a/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
@@ -19,7 +19,9 @@ class ProcessingTimeProbeBuilder : DurationProbeBuilder
 
             var processingTime = e.CompletedAt - e.StartedAt;
 
-            probe.Record(processingTime);
+            var @event = new DurationEvent(processingTime, messageTypeProcessed);
+
+            probe.Record(ref @event);
 
             return TaskExtensions.Completed;
         });

--- a/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs
@@ -1,12 +1,18 @@
 ﻿using System;
 using System.Threading.Tasks;
+using NServiceBus;
 using NServiceBus.Pipeline;
 
 class ReceivePerformanceDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
 {
     public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
     {
-        MessagePulledFromQueue?.Signal();
+        string messageType;
+        context.MessageHeaders.TryGetMessageType(out messageType);
+
+        var @event = new SignalEvent(messageType);
+
+        MessagePulledFromQueue?.Signal(ref @event);
 
         try
         {
@@ -14,11 +20,11 @@ class ReceivePerformanceDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessage
         }
         catch (Exception)
         {
-            ProcessingFailure?.Signal();
+            ProcessingFailure?.Signal(ref @event);
             throw;
         }
 
-        ProcessingSuccess?.Signal();
+        ProcessingSuccess?.Signal(ref @event);
     }
 
     public SignalProbe MessagePulledFromQueue;

--- a/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Metrics.ProbeBuilders
 {
+    using System.Collections.Generic;
     using Features;
 
     [ProbeProperties(Retries, "A message has been scheduled for retry (FLR or SLR)")]
@@ -14,8 +15,17 @@
 
         protected override void WireUp(SignalProbe probe)
         {
-            notifications.Errors.MessageHasFailedAnImmediateRetryAttempt += (sender, message) => probe.Signal();
-            notifications.Errors.MessageHasBeenSentToDelayedRetries += (sender, message) => probe.Signal();
+            notifications.Errors.MessageHasFailedAnImmediateRetryAttempt += (sender, message) => Signal(message.Headers, probe);
+            notifications.Errors.MessageHasBeenSentToDelayedRetries += (sender, message) => Signal(message.Headers, probe);
+        }
+
+        static void Signal(Dictionary<string, string> messageHeaders, SignalProbe probe)
+        {
+            string messageType;
+            messageHeaders.TryGetMessageType(out messageType);
+
+            var @event = new SignalEvent(messageType);
+            probe.Signal(ref @event);
         }
 
         readonly Notifications notifications;

--- a/src/NServiceBus.Metrics/Probes/DurationProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/DurationProbe.cs
@@ -1,4 +1,5 @@
-﻿using NServiceBus;
+﻿using System;
+using NServiceBus;
 
 class DurationProbe : Probe, IDurationProbe
 {
@@ -9,6 +10,11 @@ class DurationProbe : Probe, IDurationProbe
     public void Register(OnEvent<DurationEvent> observer)
     {
         observers += observer;
+    }
+
+    public void Register(Action<TimeSpan> observer)
+    {
+        Register((ref DurationEvent e) => observer(e.Duration));
     }
 
     internal void Record(ref DurationEvent e)

--- a/src/NServiceBus.Metrics/Probes/DurationProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/DurationProbe.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NServiceBus;
+﻿using NServiceBus;
 
 class DurationProbe : Probe, IDurationProbe
 {
@@ -7,15 +6,17 @@ class DurationProbe : Probe, IDurationProbe
     {
     }
 
-    public void Register(Action<TimeSpan> observer)
+    public void Register(OnEvent<DurationEvent> observer)
     {
         observers += observer;
     }
 
-    internal void Record(TimeSpan duration)
+    internal void Record(ref DurationEvent e)
     {
-        observers(duration);
+        observers(ref e);
     }
 
-    Action<TimeSpan> observers = span => { };
+    OnEvent<DurationEvent> observers = Empty;
+
+    static void Empty(ref DurationEvent e) { }
 }

--- a/src/NServiceBus.Metrics/Probes/SignalProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/SignalProbe.cs
@@ -1,4 +1,5 @@
-﻿using NServiceBus;
+﻿using System;
+using NServiceBus;
 
 class SignalProbe : Probe, ISignalProbe
 {
@@ -9,6 +10,11 @@ class SignalProbe : Probe, ISignalProbe
     public void Register(OnEvent<SignalEvent> observer)
     {
         observers += observer;
+    }
+
+    public void Register(Action observer)
+    {
+        Register((ref SignalEvent e) => observer());
     }
 
     internal void Signal(ref SignalEvent e)

--- a/src/NServiceBus.Metrics/Probes/SignalProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/SignalProbe.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NServiceBus;
+﻿using NServiceBus;
 
 class SignalProbe : Probe, ISignalProbe
 {
@@ -7,15 +6,17 @@ class SignalProbe : Probe, ISignalProbe
     {
     }
 
-    public void Register(Action observer)
+    public void Register(OnEvent<SignalEvent> observer)
     {
         observers += observer;
     }
 
-    internal void Signal()
+    internal void Signal(ref SignalEvent e)
     {
-        observers();
+        observers(ref e);
     }
 
-    Action observers = () => { };
+    OnEvent<SignalEvent> observers = Empty;
+
+    static void Empty(ref SignalEvent e) { }
 }

--- a/src/SampleEndpoint/SampleEndpoint.csproj
+++ b/src/SampleEndpoint/SampleEndpoint.csproj
@@ -5,6 +5,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputType>exe</OutputType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>7</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="1.1.0" />


### PR DESCRIPTION
**Breaking API change**

This PR introduces a concept of events (`DurationEvent` and `SignalEvent`), one for each existing probe type. The event types are nothing more than just a context bags that will provide additional properties to the registered probe listeners. The first property that has been added is a message type.

### Implementation details:
- events are introduced as `struct` types to minimize the imprint on the endpoint
- events are passed `by ref` to do not copy the struct if it gets bigger in time
- there's a new delegate type `OnEvent<TEvent>(ref TEvent @event)` that is used to register listeners to probes. There's no delegate with `ref` in `System` namespace that could be used for this.
