### PR TITLE
Reporting message type

### DIFF
--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -198,6 +198,8 @@ class MetricsFeature : Feature
 
     class ServiceControlRawDataReporting : FeatureStartupTask
     {
+        const string TaggedValueMetricContentType = "TaggedLongValueWriterOccurrence";
+
         public ServiceControlRawDataReporting(ProbeContext probeContext, IBuilder builder, MetricsOptions options, Dictionary<string, string> headers)
         {
             this.probeContext = probeContext;
@@ -241,14 +243,14 @@ class MetricsFeature : Feature
             var writer = new TaggedLongValueWriter();
 
             return CreateReporter(
-                w => probe.Register((ref DurationEvent d) =>
+                writeAction => probe.Register((ref DurationEvent d) =>
                 {
                     var tag = writer.GetTagId(d.MessageType ?? "");
-                    w((long)d.Duration.TotalMilliseconds, tag);
+                    writeAction((long)d.Duration.TotalMilliseconds, tag);
                 }),
                 metricType,
-                "TaggedLongValueWriterOccurrence",
-                (e, w) => writer.Write(w, e));
+                TaggedValueMetricContentType,
+                (entries, binaryWriter) => writer.Write(binaryWriter, entries));
         }
 
         RawDataReporter CreateReporter(ISignalProbe probe)
@@ -257,14 +259,14 @@ class MetricsFeature : Feature
             var writer = new TaggedLongValueWriter();
 
             return CreateReporter(
-                w => probe.Register((ref SignalEvent e) =>
+                writeAction => probe.Register((ref SignalEvent e) =>
                 {
                     var tag = writer.GetTagId(e.MessageType ?? "");
-                    w(1, tag);
+                    writeAction(1, tag);
                 }),
                 metricType,
-                "TaggedLongValueWriterOccurrence",
-                (e, w) => writer.Write(w, e));
+                TaggedValueMetricContentType,
+                (entries, binaryWriter) => writer.Write(binaryWriter, entries));
         }
 
         static string GetMetricType(IProbe probe) => $"{probe.Name.Replace(" ", string.Empty)}";

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -237,23 +237,39 @@ class MetricsFeature : Feature
 
         RawDataReporter CreateReporter(IDurationProbe probe)
         {
+            var metricType = GetMetricType(probe);
+            var writer = new TaggedLongValueWriter();
+
             return CreateReporter(
-                w => probe.Register((ref DurationEvent d) => w((long)d.Duration.TotalMilliseconds)),
-                $"{probe.Name.Replace(" ", string.Empty)}",
-                "LongValueOccurrence",
-                (e, w) => LongValueWriter.Write(w, e));
+                w => probe.Register((ref DurationEvent d) =>
+                {
+                    var tag = writer.GetTagId(d.MessageType);
+                    w((long)d.Duration.TotalMilliseconds, tag);
+                }),
+                metricType,
+                "TaggedLongValueWriterOccurrence",
+                (e, w) => writer.Write(w, e));
         }
 
         RawDataReporter CreateReporter(ISignalProbe probe)
         {
+            var metricType = GetMetricType(probe);
+            var writer = new TaggedLongValueWriter();
+
             return CreateReporter(
-                w => probe.Register((ref SignalEvent e) => w(1)),
-                $"{probe.Name.Replace(" ", string.Empty)}",
-                "Occurrence",
-                (e, w) => OccurrenceWriter.Write(w, e));
+                w => probe.Register((ref SignalEvent e) =>
+                {
+                    var tag = writer.GetTagId(e.MessageType);
+                    w(1, tag);
+                }),
+                metricType,
+                "TaggedLongValueWriterOccurrence",
+                (e, w) => writer.Write(w, e));
         }
 
-        RawDataReporter CreateReporter(Action<Action<long>> setupProbe, string metricType, string contentType, WriteOutput outputWriter)
+        static string GetMetricType(IProbe probe) => $"{probe.Name.Replace(" ", string.Empty)}";
+
+        RawDataReporter CreateReporter(Action<Action<long, int>> setupProbe, string metricType, string contentType, WriteOutput outputWriter)
         {
             var buffer = new RingBuffer();
 
@@ -269,14 +285,14 @@ class MetricsFeature : Feature
                 buffer,
                 outputWriter);
 
-            setupProbe(v =>
+            setupProbe((value, tag) =>
             {
                 var written = false;
                 var attempts = 0;
 
                 while (!written)
                 {
-                    written = buffer.TryWrite(v);
+                    written = buffer.TryWrite(value, tag);
 
                     attempts++;
 

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -243,7 +243,7 @@ class MetricsFeature : Feature
             return CreateReporter(
                 w => probe.Register((ref DurationEvent d) =>
                 {
-                    var tag = writer.GetTagId(d.MessageType);
+                    var tag = writer.GetTagId(d.MessageType ?? "");
                     w((long)d.Duration.TotalMilliseconds, tag);
                 }),
                 metricType,
@@ -259,7 +259,7 @@ class MetricsFeature : Feature
             return CreateReporter(
                 w => probe.Register((ref SignalEvent e) =>
                 {
-                    var tag = writer.GetTagId(e.MessageType);
+                    var tag = writer.GetTagId(e.MessageType ?? "");
                     w(1, tag);
                 }),
                 metricType,


### PR DESCRIPTION
This PR changes the way probes are reported to ServiceControl.Monitoring. Instead of using `OccurrenceWriter` or `LongValueWriter`, values are tagged with the message type and `TaggedLongValueWriter` is used to write them both.

### Implementation details:
This PR introduces a bit wasteful serialization of the values. `Occurences` will send additional 8 bytes for every entry, as there's no `TaggedOccurenceWriter`. The tax could be considered as big and possibly needs further discussion or introduction of a custom writer.