### PR TITLE
Explicit obsoletion of SC integration public API

### DIFF
--- a/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.ApproveNServiceBus.approved.txt
@@ -40,7 +40,7 @@ namespace NServiceBus
         public void EnableMetricTracing(System.TimeSpan interval) { }
         public void RegisterObservers(System.Action<NServiceBus.ProbeContext> register) { }
         [System.ObsoleteAttribute("Not for public use. Will be treated as an error from version 3.0.0. Will be remov" +
-            "ed in version 4.0.0.", false)]
+            "ed in version 3.0.0.", false)]
         public void SendMetricDataToServiceControl(string serviceControlMetricsAddress, System.TimeSpan interval, string instanceId = null) { }
     }
     public delegate void OnEvent<TEventType>(ref TEventType e);

--- a/src/NServiceBus.Metrics/MetricsOptions.cs
+++ b/src/NServiceBus.Metrics/MetricsOptions.cs
@@ -66,7 +66,7 @@
         /// <param name="serviceControlMetricsAddress">The transport address of the ServiceControl instance</param>
         /// <param name="interval">Interval between consecutive reports</param>
         /// <param name="instanceId">Unique, human-readable, stable between restarts, identifier for running endpoint instance.</param>
-        [ObsoleteEx(Message = "Not for public use.")]
+        [ObsoleteEx(RemoveInVersion = "3.0", TreatAsErrorFromVersion = "3.0", Message = "Not for public use.")]
         public void SendMetricDataToServiceControl(string serviceControlMetricsAddress, TimeSpan interval, string instanceId = null)
         {
             Guard.AgainstNullAndEmpty(nameof(serviceControlMetricsAddress), serviceControlMetricsAddress);


### PR DESCRIPTION
This PR explicitly defines the version when `SendMetricDataToServiceControl` will be removed.

According to my blame-vestigation this API was marked with obsolete after reasing `1.0` and still, another version was not released so we can change the versions on this attribute.

https://github.com/Particular/NServiceBus.Metrics/blame/b723509464b95ca87086172c759c52e3e7bea948/src/NServiceBus.Metrics/MetricsOptions.cs