### PR TITLE
Downgrade NServiceBus.Core references to v6

### DIFF
--- a/src/NServiceBus.Metrics.AcceptanceTests/ConfigureEndpointInMemoryPersistence.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/ConfigureEndpointInMemoryPersistence.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting.Support;
+
+public class ConfigureEndpointInMemoryPersistence : IConfigureEndpointTestExecution
+{
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
+    {
+        configuration.UsePersistence<InMemoryPersistence>();
+        return Task.FromResult(0);
+    }
+
+    public Task Cleanup()
+    {
+        // Nothing required for in-memory persistence
+        return Task.FromResult(0);
+    }
+}

--- a/src/NServiceBus.Metrics.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Messaging;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting.Support;
+using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+using NServiceBus.Configuration.AdvanceExtensibility;
+using NServiceBus.Transport;
+
+public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
+{
+    const string DefaultConnectionString = "cacheSendConnection=false;journal=false;";
+
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
+    {
+        queueBindings = configuration.GetSettings().Get<QueueBindings>();
+        var connectionString =
+            EnvironmentHelper.GetEnvironmentVariable($"{nameof(MsmqTransport)}.ConnectionString")
+            ?? DefaultConnectionString;
+        var transportConfig = configuration.UseTransport<MsmqTransport>();
+
+        transportConfig.ConnectionString(connectionString);
+
+        var routingConfig = transportConfig.Routing();
+
+        foreach (var publisher in publisherMetadata.Publishers)
+        {
+            foreach (var eventType in publisher.Events)
+            {
+                routingConfig.RegisterPublisher(eventType, publisher.PublisherName);
+            }
+        }
+
+        return Task.FromResult(0);
+    }
+
+    public Task Cleanup()
+    {
+        var allQueues = MessageQueue.GetPrivateQueuesByMachine("localhost");
+        var queuesToBeDeleted = new List<string>();
+
+        foreach (var messageQueue in allQueues)
+        {
+            using (messageQueue)
+            {
+                if (queueBindings.ReceivingAddresses.Any(ra =>
+                {
+                    var indexOfAt = ra.IndexOf("@", StringComparison.Ordinal);
+                    if (indexOfAt >= 0)
+                    {
+                        ra = ra.Substring(0, indexOfAt);
+                    }
+                    return messageQueue.QueueName.StartsWith(@"private$\" + ra, StringComparison.OrdinalIgnoreCase);
+                }))
+                {
+                    queuesToBeDeleted.Add(messageQueue.Path);
+                }
+            }
+        }
+
+        foreach (var queuePath in queuesToBeDeleted)
+        {
+            try
+            {
+                MessageQueue.Delete(queuePath);
+                Console.WriteLine("Deleted '{0}' queue", queuePath);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Could not delete queue '{0}'", queuePath);
+            }
+        }
+
+        MessageQueue.ClearConnectionCache();
+
+        return Task.FromResult(0);
+    }
+
+    QueueBindings queueBindings;
+}

--- a/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -1,13 +1,50 @@
 ﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
 {
+    using System;
+    using System.Threading.Tasks;
     using AcceptanceTesting.Support;
     using ObjectBuilder;
 
     public static class ConfigureExtensions
     {
+        public static Task DefineTransport(this EndpointConfiguration config, RunSettings settings, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
+        {
+            if (TestSuiteConstraints.Current.TransportConfiguration == null)
+            {
+                throw new Exception($"No valid transport configuration found. Configure a transport by assigning {nameof(TestSuiteConstraints)}.{nameof(TestSuiteConstraints.TransportConfiguration)}.");
+            }
+
+            return ConfigureTestExecution(TestSuiteConstraints.Current.TransportConfiguration, config, settings, endpointCustomizationConfiguration.EndpointName, endpointCustomizationConfiguration.PublisherMetadata);
+        }
+
+        public static Task DefinePersistence(this EndpointConfiguration config, RunSettings settings, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
+        {
+            if (TestSuiteConstraints.Current.PersistenceConfiguration == null)
+            {
+                throw new Exception($"No valid persistence configuration found. Configure a persistence by assigning {nameof(TestSuiteConstraints)}.{nameof(TestSuiteConstraints.PersistenceConfiguration)}.");
+            }
+
+            return ConfigureTestExecution(TestSuiteConstraints.Current.PersistenceConfiguration, config, settings, endpointCustomizationConfiguration.EndpointName, endpointCustomizationConfiguration.PublisherMetadata);
+        }
+
         public static void RegisterComponentsAndInheritanceHierarchy(this EndpointConfiguration builder, RunDescriptor runDescriptor)
         {
             builder.RegisterComponents(r => { RegisterInheritanceHierarchyOfContextOnContainer(runDescriptor, r); });
+        }
+
+        static async Task ConfigureTestExecution(IConfigureEndpointTestExecution configurer, EndpointConfiguration config, RunSettings settings, string endpointName, PublisherMetadata publisherMetadata)
+        {
+            await configurer.Configure(endpointName, config, settings, publisherMetadata)
+                .ConfigureAwait(false);
+
+            ActiveTestExecutionConfigurer cleaners;
+            var cleanerKey = "ConfigureTestExecution." + endpointName;
+            if (!settings.TryGet(cleanerKey, out cleaners))
+            {
+                cleaners = new ActiveTestExecutionConfigurer();
+                settings.Set(cleanerKey, cleaners);
+            }
+            cleaners.Add(configurer);
         }
 
         static void RegisterInheritanceHierarchyOfContextOnContainer(RunDescriptor runDescriptor, IConfigureComponents r)
@@ -18,6 +55,12 @@
                 r.RegisterSingleton(type, runDescriptor.ScenarioContext);
                 type = type.BaseType;
             }
+        }
+
+        enum TestDependencyType
+        {
+            Transport,
+            Persistence
         }
     }
 }

--- a/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Support;
+    using Config.ConfigurationSource;
+
+    public class DefaultPublisher : IEndpointSetupTemplate
+    {
+#pragma warning disable CS0618
+        public Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization)
+#pragma warning restore CS0618
+        {
+            return new DefaultServer().GetConfiguration(runDescriptor, endpointConfiguration, configSource, configurationBuilderCustomization);
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/EndpointConfigurationExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using Configuration.AdvanceExtensibility;
+
+    public static class EndpointConfigurationExtensions
+    {
+        public static TransportExtensions ConfigureTransport(this EndpointConfiguration endpointConfiguration)
+        {
+            return new TransportExtensions(endpointConfiguration.GetSettings());
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/Requires.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/Requires.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using NUnit.Framework;
+
+    static class Requires
+    {
+        public static void DtcSupport()
+        {
+            if (!TestSuiteConstraints.Current.SupportsDtc)
+            {
+                Assert.Ignore("Ignoring this test because it requires DTC transaction support from the transport.");
+            }
+        }
+
+        public static void CrossQueueTransactionSupport()
+        {
+            if (!TestSuiteConstraints.Current.SupportsCrossQueueTransactions)
+            {
+                Assert.Ignore("Ignoring this test because it requires cross queue transaction support from the transport.");
+            }
+        }
+
+        public static void NativePubSubSupport()
+        {
+            if (!TestSuiteConstraints.Current.SupportsNativePubSub)
+            {
+                Assert.Ignore("Ignoring this test because it requires native publish subscribe support from the transport.");
+            }
+        }
+
+        public static void MessageDrivenPubSub()
+        {
+            if (TestSuiteConstraints.Current.SupportsNativePubSub)
+            {
+                Assert.Ignore("Ignoring this test because it requires message driven publish subscribe but this test suite uses native publish subscribe.");
+            }
+        }
+
+        public static void TimeoutStorage()
+        {
+            if (TestSuiteConstraints.Current.SupportsNativeDeferral)
+            {
+                Assert.Ignore("Ignoring this test because it requires the timeout manager but this transport provides native deferral.");
+            }
+        }
+
+        public static void OutboxPersistence()
+        {
+            if (!TestSuiteConstraints.Current.SupportsOutbox)
+            {
+                Assert.Ignore("Ignoring this tests because it requires a persistence providing an Outbox storage.");
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting.Customization;
+    using AcceptanceTesting.Support;
+    using Features;
+    using Config.ConfigurationSource;
+
+    public class ServerWithNoDefaultPersistenceDefinitions : IEndpointSetupTemplate
+    {
+        public ServerWithNoDefaultPersistenceDefinitions()
+        {
+            typesToInclude = new List<Type>();
+        }
+
+        public ServerWithNoDefaultPersistenceDefinitions(List<Type> typesToInclude)
+        {
+            this.typesToInclude = typesToInclude;
+        }
+
+#pragma warning disable CS0618
+        public async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization)
+#pragma warning restore CS0618
+        {
+            var settings = runDescriptor.Settings;
+
+            var types = endpointConfiguration.GetTypesScopedByTestClass();
+
+            typesToInclude.AddRange(types);
+
+            var builder = new EndpointConfiguration(endpointConfiguration.EndpointName);
+            builder.TypesToIncludeInScan(typesToInclude);
+            builder.CustomConfigurationSource(configSource);
+            builder.EnableInstallers();
+
+            builder.DisableFeature<TimeoutManager>();
+            builder.Recoverability()
+                .Delayed(delayed => delayed.NumberOfRetries(0))
+                .Immediate(immediate => immediate.NumberOfRetries(0));
+            builder.SendFailedMessagesTo("error");
+
+            await builder.DefineTransport(settings, endpointConfiguration)
+                .ConfigureAwait(false);
+
+            builder.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
+
+            configurationBuilderCustomization(builder);
+
+            return builder;
+        }
+
+        List<Type> typesToInclude;
+    }
+}

--- a/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/TestSuiteConstraints.cs
@@ -1,0 +1,34 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using AcceptanceTesting.Support;
+
+    public interface ITestSuiteConstraints
+    {
+        bool SupportsDtc { get; }
+
+        bool SupportsCrossQueueTransactions { get; }
+
+        bool SupportsNativePubSub { get; }
+
+        bool SupportsNativeDeferral { get; }
+
+        bool SupportsOutbox { get; }
+
+        IConfigureEndpointTestExecution TransportConfiguration { get; }
+
+        IConfigureEndpointTestExecution PersistenceConfiguration { get; }
+    }
+
+    // ReSharper disable once PartialTypeWithSinglePart
+    public class TestSuiteConstraints : ITestSuiteConstraints
+    {
+        public static TestSuiteConstraints Current = new TestSuiteConstraints();
+        public bool SupportsDtc => true;
+        public bool SupportsCrossQueueTransactions => true;
+        public bool SupportsNativePubSub => false;
+        public bool SupportsNativeDeferral => false;
+        public bool SupportsOutbox => true;
+        public IConfigureEndpointTestExecution TransportConfiguration => new ConfigureEndpointMsmqTransport();
+        public IConfigureEndpointTestExecution PersistenceConfiguration => new ConfigureEndpointInMemoryPersistence();
+    }
+}

--- a/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
+++ b/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="1.1.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="6.4.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.4.0" />
     <ProjectReference Include="..\NServiceBus.Metrics\NServiceBus.Metrics.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />

--- a/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
+++ b/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
@@ -9,9 +9,12 @@
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="1.1.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NServiceBus" Version="6.4.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.4.0" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="6.2.0" />
     <ProjectReference Include="..\NServiceBus.Metrics\NServiceBus.Metrics.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Messaging" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
+++ b/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="6.4.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="ApprovalTests" Version="3.*" />
     <PackageReference Include="ApprovalUtilities" Version="3.*" />

--- a/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus
 {
-    using Configuration.AdvancedExtensibility;
+    using Configuration.AdvanceExtensibility;
     using Features;
     using Settings;
 

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Metrics.NET" Version="0.4.8" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="6.4.0" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
     <PackageReference Include="ServiceControl.Monitoring.Data" Version="1.0.2" PrivateAssets="All" />

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Metrics.NET" Version="0.4.8" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus" Version="6.2.0" />
+    <PackageReference Include="NServiceBus" Version="[6.*, 7.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
     <PackageReference Include="ServiceControl.Monitoring.Data" Version="1.0.2" PrivateAssets="All" />

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Metrics.NET" Version="0.4.8" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus" Version="6.4.0" />
+    <PackageReference Include="NServiceBus" Version="6.2.0" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
     <PackageReference Include="ServiceControl.Monitoring.Data" Version="1.0.2" PrivateAssets="All" />

--- a/src/SampleEndpoint/SampleEndpoint.csproj
+++ b/src/SampleEndpoint/SampleEndpoint.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.*" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.0.0-*" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="1.1.0" />
     <PackageReference Include="Metrics.NET" Version="0.4.8" />
-    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <PackageReference Include="NServiceBus" Version="6.4.0" />
     <ProjectReference Include="..\NServiceBus.Metrics\NServiceBus.Metrics.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR downgrades references to NServiceBus.Core to v6:
 * This has been done both for core and other packages that depend on it
 * Changes have been made to acceptance tests to cater for differences in `NServiceBus.AcceptanceTesting` differences
* [x] WARNING: in current version the NServiceBus package reference in output `.nupkg` is targeting version >= `6.2.0`. It should be `6.0.0` <= ver < `7.0.0`