### PR TITLE
Delayed SetUpObservers

### DIFF
--- a/src/NServiceBus.Metrics/Probes/DurationProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/DurationProbe.cs
@@ -9,7 +9,10 @@ class DurationProbe : Probe, IDurationProbe
 
     public void Register(OnEvent<DurationEvent> observer)
     {
-        observers += observer;
+        lock (Lock)
+        {
+            observers += observer;
+        }
     }
 
     public void Register(Action<TimeSpan> observer)
@@ -22,7 +25,8 @@ class DurationProbe : Probe, IDurationProbe
         observers(ref e);
     }
 
-    OnEvent<DurationEvent> observers = Empty;
+    volatile OnEvent<DurationEvent> observers = Empty;
+    readonly object Lock = new object();
 
     static void Empty(ref DurationEvent e) { }
 }

--- a/src/NServiceBus.Metrics/Probes/SignalProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/SignalProbe.cs
@@ -9,7 +9,10 @@ class SignalProbe : Probe, ISignalProbe
 
     public void Register(OnEvent<SignalEvent> observer)
     {
-        observers += observer;
+        lock (Lock)
+        {
+            observers += observer;
+        }
     }
 
     public void Register(Action observer)
@@ -22,7 +25,8 @@ class SignalProbe : Probe, ISignalProbe
         observers(ref e);
     }
 
-    OnEvent<SignalEvent> observers = Empty;
+    volatile OnEvent<SignalEvent> observers = Empty;
+    readonly object Lock = new object();
 
     static void Empty(ref SignalEvent e) { }
 }


### PR DESCRIPTION
This PR moves the initialization of registered observers to a dedicated `FeatureStartupTask` allowing other Features to register their observers in the Setup method.