### PR TITLE
NServiceBus references constrained to [6.2.0, 7.0.0)

### DIFF
--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Metrics.NET" Version="0.4.8" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus" Version="[6.0.0, 7.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[6.2.0, 7.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
     <PackageReference Include="ServiceControl.Monitoring.Data" Version="1.0.2" PrivateAssets="All" />

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Metrics.NET" Version="0.4.8" PrivateAssets="All" />
-    <PackageReference Include="NServiceBus" Version="[6.*, 7.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[6.0.0, 7.0.0)" />
     <PackageReference Include="Fody" Version="2.*" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.*" PrivateAssets="All" />
     <PackageReference Include="ServiceControl.Monitoring.Data" Version="1.0.2" PrivateAssets="All" />


### PR DESCRIPTION
This PR fixes an upper constraint for `NServiceBus` dependency. The lower bound is set to `6.2` as it introduces public access to `ReceivePipelineCompleted` event.