### PR TITLE
[SPIKE] Open metrics

### DIFF
--- a/src/NServiceBus.Metrics.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.Approve.approved.txt
@@ -9,6 +9,12 @@ namespace NServiceBus
         public readonly string MessageType;
         public DurationEvent(System.TimeSpan duration, string messageType) { }
     }
+    public struct GaugeEvent
+    {
+        public readonly string Tag;
+        public readonly long Value;
+        public GaugeEvent(long value, string tag) { }
+    }
     public interface IDurationProbe : NServiceBus.IProbe
     {
         void Register(NServiceBus.OnEvent<NServiceBus.DurationEvent> observer);
@@ -17,6 +23,10 @@ namespace NServiceBus
         where TEvent :  struct
     {
         void Record(ref TEvent e);
+    }
+    public interface IGaugeProbe : NServiceBus.IProbe
+    {
+        void Register(NServiceBus.OnEvent<NServiceBus.GaugeEvent> observer);
     }
     public interface IProbe
     {
@@ -41,6 +51,7 @@ namespace NServiceBus
     {
         public MetricsSensorFactory() { }
         public NServiceBus.IEventSensor<NServiceBus.DurationEvent> CreateDurationSensor(string name, string description) { }
+        public NServiceBus.IEventSensor<NServiceBus.GaugeEvent> CreateGaugeSensor(string name, string description) { }
         public NServiceBus.IEventSensor<NServiceBus.SignalEvent> CreateSignalSensor(string name, string description) { }
     }
     public delegate void OnEvent<TEventType>(ref TEventType e);
@@ -48,6 +59,7 @@ namespace NServiceBus
     {
         public ProbeContext(System.Collections.Generic.IReadOnlyCollection<NServiceBus.IDurationProbe> durations, System.Collections.Generic.IReadOnlyCollection<NServiceBus.ISignalProbe> signals) { }
         public System.Collections.Generic.IReadOnlyCollection<NServiceBus.IDurationProbe> Durations { get; }
+        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.IGaugeProbe> Gauges { get; }
         public System.Collections.Generic.IReadOnlyCollection<NServiceBus.ISignalProbe> Signals { get; }
     }
     public struct SignalEvent

--- a/src/NServiceBus.Metrics.Tests/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.Approve.approved.txt
@@ -13,6 +13,11 @@ namespace NServiceBus
     {
         void Register(NServiceBus.OnEvent<NServiceBus.DurationEvent> observer);
     }
+    public interface IEventSensor<TEvent>
+        where TEvent :  struct
+    {
+        void Record(ref TEvent e);
+    }
     public interface IProbe
     {
         string Description { get; }
@@ -31,6 +36,12 @@ namespace NServiceBus
     {
         public MetricsOptions() { }
         public void RegisterObservers(System.Action<NServiceBus.ProbeContext> register) { }
+    }
+    public class MetricsSensorFactory
+    {
+        public MetricsSensorFactory() { }
+        public NServiceBus.IEventSensor<NServiceBus.DurationEvent> CreateDurationSensor(string name, string description) { }
+        public NServiceBus.IEventSensor<NServiceBus.SignalEvent> CreateSignalSensor(string name, string description) { }
     }
     public delegate void OnEvent<TEventType>(ref TEventType e);
     public class ProbeContext

--- a/src/NServiceBus.Metrics/IGaugeProbe.cs
+++ b/src/NServiceBus.Metrics/IGaugeProbe.cs
@@ -1,0 +1,38 @@
+namespace NServiceBus
+{
+    /// <summary>
+    /// Probe that measures an exact value
+    /// </summary>
+    public interface IGaugeProbe : IProbe
+    {
+        /// <summary>
+        /// Enables registering action called on event occurrence.
+        /// </summary>
+        void Register(OnEvent<GaugeEvent> observer);
+    }
+
+    /// <summary>
+    /// Provides data for a single recording of the gauge
+    /// </summary>
+    public struct GaugeEvent
+    {
+        /// <summary>
+        /// Creates the Gauge Event
+        /// </summary>
+        public GaugeEvent(long value, string tag)
+        {
+            Value = value;
+            Tag = tag;
+        }
+
+        /// <summary>
+        /// The measured value
+        /// </summary>
+        public readonly long Value;
+
+        /// <summary>
+        /// A tag to apply to this measurement, if any.
+        /// </summary>
+        public readonly string Tag;
+    }
+}

--- a/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
@@ -16,6 +16,7 @@
         /// <returns>An object containing configuration options for the Metrics feature.</returns>
         public static MetricsOptions EnableMetrics(this SettingsHolder settings)
         {
+            settings.GetOrCreate<MetricsSensorFactory>();
             var options = settings.GetOrCreate<MetricsOptions>();
             settings.Set(typeof(MetricsFeature).FullName, FeatureState.Enabled);
             return options;

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Metrics.ProbeBuilders;
@@ -10,21 +9,28 @@ class MetricsFeature : Feature
     {
         context.ThrowIfSendonly();
 
-        var probeContext = BuildProbes(context);
+        var sensorFactory = new MetricsSensorFactory();
+
+        AddStandardProbes(context, sensorFactory);
 
         var settings = context.Settings;
         var options = settings.Get<MetricsOptions>();
 
-        context.RegisterStartupTask(new SetupRegisteredObservers(options, probeContext));
+        context.RegisterStartupTask(new SetupRegisteredObservers(options, sensorFactory));
     }
 
-    static ProbeContext BuildProbes(FeatureConfigurationContext context)
+    static void AddStandardProbes(FeatureConfigurationContext context, MetricsSensorFactory sensorFactory)
     {
         var durationBuilders = new DurationProbeBuilder[]
         {
             new CriticalTimeProbeBuilder(context),
             new ProcessingTimeProbeBuilder(context)
         };
+
+        foreach (var durationProbeBuilder in durationBuilders)
+        {
+            sensorFactory.AddExisting(durationProbeBuilder.Build());
+        }
 
         var performanceDiagnosticsBehavior = new ReceivePerformanceDiagnosticsBehavior();
 
@@ -42,25 +48,26 @@ class MetricsFeature : Feature
             new RetriesProbeBuilder(context)
         };
 
-        return new ProbeContext(
-            durationBuilders.Select(b => b.Build()).ToArray(),
-            signalBuilders.Select(b => b.Build()).ToArray()
-        );
+        foreach (var signalProbeBuilder in signalBuilders)
+        {
+            sensorFactory.AddExisting(signalProbeBuilder.Build());
+        }
     }
 
     class SetupRegisteredObservers : FeatureStartupTask
     {
         readonly MetricsOptions options;
-        readonly ProbeContext probeContext;
+        readonly MetricsSensorFactory sensorFactory;
 
-        public SetupRegisteredObservers(MetricsOptions options, ProbeContext probeContext)
+        public SetupRegisteredObservers(MetricsOptions options, MetricsSensorFactory sensorFactory)
         {
             this.options = options;
-            this.probeContext = probeContext;
+            this.sensorFactory = sensorFactory;
         }
 
         protected override Task OnStart(IMessageSession session)
         {
+            var probeContext = sensorFactory.CreateProbeContext();
             options.SetUpObservers(probeContext);
             return Task.FromResult(0);
         }

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -9,7 +9,7 @@ class MetricsFeature : Feature
     {
         context.ThrowIfSendonly();
 
-        var sensorFactory = new MetricsSensorFactory();
+        var sensorFactory = context.Settings.Get<MetricsSensorFactory>();
 
         AddStandardProbes(context, sensorFactory);
 

--- a/src/NServiceBus.Metrics/MetricsSensorFactory.cs
+++ b/src/NServiceBus.Metrics/MetricsSensorFactory.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace NServiceBus
+{
+    /// <summary>
+    /// Factory for creating sensors
+    /// </summary>
+    public class MetricsSensorFactory
+    {
+        IList<Probe> probes = new List<Probe>();
+
+        /// <summary>
+        /// Creates a sensor for recording duration events
+        /// </summary>
+        public IEventSensor<DurationEvent> CreateDurationSensor(string name, string description)
+        {
+            var probe = new DurationProbe(name, description);
+            probes.Add(probe);
+            return probe;
+        }
+
+        /// <summary>
+        /// Creates a sensor for recording signal events
+        /// </summary>
+        public IEventSensor<SignalEvent> CreateSignalSensor(string name, string description)
+        {
+            var probe = new SignalProbe(name, description);
+            probes.Add(probe);
+            return probe;
+        }
+
+        internal ProbeContext CreateProbeContext()
+        {
+            return new ProbeContext(
+                probes.OfType<IDurationProbe>().ToList().AsReadOnly(),
+                probes.OfType<ISignalProbe>().ToList().AsReadOnly()
+            );
+        }
+
+        internal void AddExisting(Probe probe)
+        {
+            probes.Add(probe);
+        }
+    }
+}

--- a/src/NServiceBus.Metrics/MetricsSensorFactory.cs
+++ b/src/NServiceBus.Metrics/MetricsSensorFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace NServiceBus
 {
@@ -8,7 +7,7 @@ namespace NServiceBus
     /// </summary>
     public class MetricsSensorFactory
     {
-        IList<Probe> probes = new List<Probe>();
+        ICollection<IProbe> probes = new List<IProbe>();
 
         /// <summary>
         /// Creates a sensor for recording duration events
@@ -30,15 +29,22 @@ namespace NServiceBus
             return probe;
         }
 
-        internal ProbeContext CreateProbeContext()
+        /// <summary>
+        /// Creates a sensor for recording gauge readings
+        /// </summary>
+        public IEventSensor<GaugeEvent> CreateGaugeSensor(string name, string description)
         {
-            return new ProbeContext(
-                probes.OfType<IDurationProbe>().ToList().AsReadOnly(),
-                probes.OfType<ISignalProbe>().ToList().AsReadOnly()
-            );
+            var probe = new GaugeProbe(name, description);
+            probes.Add(probe);
+            return probe;
         }
 
-        internal void AddExisting(Probe probe)
+        internal ProbeContext CreateProbeContext()
+        {
+            return new ProbeContext(probes);
+        }
+
+        internal void AddExisting(IProbe probe)
         {
             probes.Add(probe);
         }

--- a/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs
@@ -11,7 +11,7 @@ class ReceivePerformanceDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessage
 
         var @event = new SignalEvent(messageType);
 
-        MessagePulledFromQueue?.Signal(ref @event);
+        MessagePulledFromQueue?.Record(ref @event);
 
         try
         {
@@ -19,11 +19,11 @@ class ReceivePerformanceDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessage
         }
         catch (Exception)
         {
-            ProcessingFailure?.Signal(ref @event);
+            ProcessingFailure?.Record(ref @event);
             throw;
         }
 
-        ProcessingSuccess?.Signal(ref @event);
+        ProcessingSuccess?.Record(ref @event);
     }
 
     public SignalProbe MessagePulledFromQueue;

--- a/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
@@ -25,7 +25,7 @@
             messageHeaders.TryGetMessageType(out var messageType);
 
             var @event = new SignalEvent(messageType);
-            probe.Signal(ref @event);
+            probe.Record(ref @event);
         }
 
         Notifications notifications;

--- a/src/NServiceBus.Metrics/ProbeContext.cs
+++ b/src/NServiceBus.Metrics/ProbeContext.cs
@@ -1,12 +1,14 @@
 ﻿namespace NServiceBus
 {
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Stores available probes
     /// </summary>
     public class ProbeContext
     {
+        // TODO: Obsolete this constructor
         /// <summary>
         /// Creates <see cref="ProbeContext"/>.
         /// </summary>
@@ -14,6 +16,14 @@
         {
             Durations = durations;
             Signals = signals;
+            Gauges = Enumerable.Empty<IGaugeProbe>().ToArray();
+        }
+
+        internal ProbeContext(ICollection<IProbe> probes)
+        {
+            Durations = probes.OfType<IDurationProbe>().ToArray();
+            Signals = probes.OfType<ISignalProbe>().ToArray();
+            Gauges = probes.OfType<IGaugeProbe>().ToArray();
         }
 
         /// <summary>
@@ -25,5 +35,10 @@
         /// Signal type probes.
         /// </summary>
         public IReadOnlyCollection<ISignalProbe> Signals { get; }
+
+        /// <summary>
+        /// Gauge type probes.
+        /// </summary>
+        public IReadOnlyCollection<IGaugeProbe> Gauges { get; }
     }
 }

--- a/src/NServiceBus.Metrics/Probes/DurationProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/DurationProbe.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NServiceBus;
 
-class DurationProbe : Probe, IDurationProbe
+class DurationProbe : Probe, IDurationProbe, IEventSensor<DurationEvent>
 {
     public DurationProbe(string name, string description) : base(name, description)
     {
@@ -20,7 +20,7 @@ class DurationProbe : Probe, IDurationProbe
         Register((ref DurationEvent e) => observer(e.Duration));
     }
 
-    internal void Record(ref DurationEvent e)
+    public void Record(ref DurationEvent e)
     {
         observers(ref e);
     }

--- a/src/NServiceBus.Metrics/Probes/GaugeProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/GaugeProbe.cs
@@ -1,0 +1,26 @@
+﻿using NServiceBus;
+
+class GaugeProbe : Probe, IGaugeProbe, IEventSensor<GaugeEvent>
+{
+    public GaugeProbe(string name, string description) : base(name, description)
+    {
+    }
+
+    public void Register(OnEvent<GaugeEvent> observer)
+    {
+        lock (Lock)
+        {
+            observers += observer;
+        }
+    }
+
+    public void Record(ref GaugeEvent e)
+    {
+        observers(ref e);
+    }
+
+    volatile OnEvent<GaugeEvent> observers = Empty;
+    readonly object Lock = new object();
+
+    static void Empty(ref GaugeEvent e) { }
+}

--- a/src/NServiceBus.Metrics/Probes/IEventSensor.cs
+++ b/src/NServiceBus.Metrics/Probes/IEventSensor.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus
+{
+    /// <summary>
+    /// A sensor for recording events
+    /// </summary>
+    /// <typeparam name="TEvent">The type of event being recorded</typeparam>
+    public interface IEventSensor<TEvent> where TEvent : struct
+    {
+        /// <summary>
+        /// Records an event
+        /// </summary>
+        /// <param name="e">The event</param>
+        void Record(ref TEvent e);
+    }
+}

--- a/src/NServiceBus.Metrics/Probes/SignalProbe.cs
+++ b/src/NServiceBus.Metrics/Probes/SignalProbe.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NServiceBus;
 
-class SignalProbe : Probe, ISignalProbe
+class SignalProbe : Probe, ISignalProbe, IEventSensor<SignalEvent>
 {
     public SignalProbe(string name, string description) : base(name, description)
     {
@@ -20,7 +20,7 @@ class SignalProbe : Probe, ISignalProbe
         Register((ref SignalEvent e) => observer());
     }
 
-    internal void Signal(ref SignalEvent e)
+    public void Record(ref SignalEvent e)
     {
         observers(ref e);
     }


### PR DESCRIPTION
Allowing external sources to create their own metrics in the metrics context.

Needed for native queue length reporting.