### PR TITLE
Alternative that only uses the public API

### DIFF
--- a/src/NServiceBus.Metrics.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -23,7 +23,6 @@ namespace NServiceBus
     }
     public class static MetricsConfigurationExtensions
     {
-        public static NServiceBus.MetricsOptions EnableMetrics(this NServiceBus.Settings.SettingsHolder settings) { }
         public static NServiceBus.MetricsOptions EnableMetrics(this NServiceBus.EndpointConfiguration endpointConfiguration) { }
     }
     public class MetricsOptions

--- a/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
@@ -21,7 +21,6 @@
             var options = settings.GetOrCreate<MetricsOptions>();
             settings.Set(typeof(MetricsFeature).FullName, FeatureState.Enabled);
 
-            // any ideas how to get rid of the closure?
             endpointConfiguration.Recoverability().Immediate(c => c.OnMessageBeingRetried(m => options.Immediate(m)));
             endpointConfiguration.Recoverability().Delayed(c => c.OnMessageBeingRetried(m => options.Delayed(m)));
 

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -10,15 +10,15 @@ class MetricsFeature : Feature
     {
         context.ThrowIfSendonly();
 
-        var probeContext = BuildProbes(context);
-
         var settings = context.Settings;
         var options = settings.Get<MetricsOptions>();
+
+        var probeContext = BuildProbes(context, options);
 
         context.RegisterStartupTask(new SetupRegisteredObservers(options, probeContext));
     }
 
-    static ProbeContext BuildProbes(FeatureConfigurationContext context)
+    static ProbeContext BuildProbes(FeatureConfigurationContext context, MetricsOptions options)
     {
         var durationBuilders = new DurationProbeBuilder[]
         {
@@ -39,7 +39,7 @@ class MetricsFeature : Feature
             new MessagePulledFromQueueProbeBuilder(performanceDiagnosticsBehavior),
             new MessageProcessingFailureProbeBuilder(performanceDiagnosticsBehavior),
             new MessageProcessingSuccessProbeBuilder(performanceDiagnosticsBehavior),
-            new RetriesProbeBuilder(context)
+            new RetriesProbeBuilder(options)
         };
 
         return new ProbeContext(

--- a/src/NServiceBus.Metrics/MetricsOptions.cs
+++ b/src/NServiceBus.Metrics/MetricsOptions.cs
@@ -1,12 +1,17 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
+    using Faults;
 
     /// <summary>
     /// Provides configuration options for Metrics feature
     /// </summary>
     public class MetricsOptions
     {
+        internal Func<ImmediateRetryMessage, Task> Immediate { get; set; } = m => Task.CompletedTask;
+        internal Func<DelayedRetryMessage, Task> Delayed { get; set; } = m => Task.CompletedTask;
+
         /// <summary>
         /// Enables registering observers to available probes.
         /// </summary>
@@ -23,6 +28,6 @@
             registerObservers(probeContext);
         }
 
-        Action<ProbeContext> registerObservers = c => {};
+        Action<ProbeContext> registerObservers = c => { };
     }
 }


### PR DESCRIPTION
If https://github.com/Particular/NServiceBus.Metrics.PerformanceCounters/pull/126 is in this would remove the usage of the reflection hack

I think it is fine given performance counter package is the only one why we introduced this API as proven by the PR it doesn't even really require it