### PR TITLE
Make MetricsFeature public

### DIFF
--- a/src/NServiceBus.Metrics.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Metrics.Tests/APIApprovals.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using NServiceBus.Metrics;
+using NUnit.Framework;
 using Particular.Approvals;
 using PublicApiGenerator;
 

--- a/src/NServiceBus.Metrics.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -43,3 +43,11 @@ namespace NServiceBus
         public SignalEvent(string messageType) { }
     }
 }
+namespace NServiceBus.Metrics
+{
+    public class MetricsFeature : NServiceBus.Features.Feature
+    {
+        public MetricsFeature() { }
+        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+    }
+}

--- a/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
+++ b/src/NServiceBus.Metrics/MetricsConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 {
     using Configuration.AdvancedExtensibility;
     using Features;
+    using Metrics;
 
     /// <summary>
     /// Extends Endpoint Configuration to provide Metric options

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -1,70 +1,77 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
-using NServiceBus;
-using NServiceBus.Features;
-using NServiceBus.Metrics.ProbeBuilders;
-
-class MetricsFeature : Feature
+﻿namespace NServiceBus.Metrics
 {
-    protected override void Setup(FeatureConfigurationContext context)
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.Features;
+    using ProbeBuilders;
+
+    /// <summary>
+    /// Provides the infrastructure that notifies observers about collected metrics.
+    /// </summary>
+    public class MetricsFeature : Feature
     {
-        context.ThrowIfSendonly();
-
-        var settings = context.Settings;
-        var options = settings.Get<MetricsOptions>();
-
-        var probeContext = BuildProbes(context, options);
-
-        context.RegisterStartupTask(new SetupRegisteredObservers(options, probeContext));
-    }
-
-    static ProbeContext BuildProbes(FeatureConfigurationContext context, MetricsOptions options)
-    {
-        var durationBuilders = new DurationProbeBuilder[]
+        /// <inheritdoc />
+        protected override void Setup(FeatureConfigurationContext context)
         {
+            context.ThrowIfSendonly();
+
+            var settings = context.Settings;
+            var options = settings.Get<MetricsOptions>();
+
+            var probeContext = BuildProbes(context, options);
+
+            context.RegisterStartupTask(new SetupRegisteredObservers(options, probeContext));
+        }
+
+        static ProbeContext BuildProbes(FeatureConfigurationContext context, MetricsOptions options)
+        {
+            var durationBuilders = new DurationProbeBuilder[]
+            {
             new CriticalTimeProbeBuilder(context),
             new ProcessingTimeProbeBuilder(context)
-        };
+            };
 
-        var performanceDiagnosticsBehavior = new ReceivePerformanceDiagnosticsBehavior();
+            var performanceDiagnosticsBehavior = new ReceivePerformanceDiagnosticsBehavior();
 
-        context.Pipeline.Register(
-            "NServiceBus.Metrics.ReceivePerformanceDiagnosticsBehavior",
-            performanceDiagnosticsBehavior,
-            "Provides various performance counters for receive statistics"
-        );
+            context.Pipeline.Register(
+                "NServiceBus.Metrics.ReceivePerformanceDiagnosticsBehavior",
+                performanceDiagnosticsBehavior,
+                "Provides various performance counters for receive statistics"
+            );
 
-        var signalBuilders = new SignalProbeBuilder[]
-        {
+            var signalBuilders = new SignalProbeBuilder[]
+            {
             new MessagePulledFromQueueProbeBuilder(performanceDiagnosticsBehavior),
             new MessageProcessingFailureProbeBuilder(performanceDiagnosticsBehavior),
             new MessageProcessingSuccessProbeBuilder(performanceDiagnosticsBehavior),
             new RetriesProbeBuilder(options)
-        };
+            };
 
-        return new ProbeContext(
-            durationBuilders.Select(b => b.Build()).ToArray(),
-            signalBuilders.Select(b => b.Build()).ToArray()
-        );
-    }
-
-    class SetupRegisteredObservers : FeatureStartupTask
-    {
-        readonly MetricsOptions options;
-        readonly ProbeContext probeContext;
-
-        public SetupRegisteredObservers(MetricsOptions options, ProbeContext probeContext)
-        {
-            this.options = options;
-            this.probeContext = probeContext;
+            return new ProbeContext(
+                durationBuilders.Select(b => b.Build()).ToArray(),
+                signalBuilders.Select(b => b.Build()).ToArray()
+            );
         }
 
-        protected override Task OnStart(IMessageSession session)
+        class SetupRegisteredObservers : FeatureStartupTask
         {
-            options.SetUpObservers(probeContext);
-            return Task.FromResult(0);
-        }
+            readonly MetricsOptions options;
+            readonly ProbeContext probeContext;
 
-        protected override Task OnStop(IMessageSession session) => Task.FromResult(0);
+            public SetupRegisteredObservers(MetricsOptions options, ProbeContext probeContext)
+            {
+                this.options = options;
+                this.probeContext = probeContext;
+            }
+
+            protected override Task OnStart(IMessageSession session)
+            {
+                options.SetUpObservers(probeContext);
+                return Task.FromResult(0);
+            }
+
+            protected override Task OnStop(IMessageSession session) => Task.FromResult(0);
+        }
     }
 }


### PR DESCRIPTION
Makes the `MetricsFeature` public so that other packages that build upon this package can define a strongly typed dependency on their feature to ensure that their feature and FeatureStartupTasks are invoked after the `MetricsFeature` (and it's FST).

Once merged, https://github.com/Particular/NServiceBus.Metrics.ServiceControl/blob/master/src/NServiceBus.Metrics.ServiceControl/ReportingFeature.cs#L28 needs to be updated. To my knowledge (and after searching in GitHub) I haven't found any other reference to this feature)