### PR TITLE
Use the OnComplete event to make sure critical time, processing time, message failed and message succeded metric are correct

### DIFF
--- a/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -6,8 +6,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting.Customization;
     using AcceptanceTesting.Support;
-    using Configuration.AdvancedExtensibility;
-    using Features;
 
     public class DefaultServer : IEndpointSetupTemplate
     {

--- a/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
+++ b/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-PullRequest5936.873" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-Alpha.866" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
+++ b/src/NServiceBus.Metrics.AcceptanceTests/NServiceBus.Metrics.AcceptanceTests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.852" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-PullRequest5936.873" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
+++ b/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-PullRequest5936.873" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-Alpha.866" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />

--- a/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
+++ b/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.852" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-PullRequest5936.873" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />

--- a/src/NServiceBus.Metrics/Extensions.cs
+++ b/src/NServiceBus.Metrics/Extensions.cs
@@ -5,9 +5,9 @@ using NServiceBus.Features;
 
 static class Extensions
 {
-    public static bool TryGetTimeSent(this ReceivePipelineCompleted completed, out DateTimeOffset timeSent)
+    public static bool TryGetTimeSent(this ReceiveCompleted completed, out DateTimeOffset timeSent)
     {
-        var headers = completed.ProcessedMessage.Headers;
+        var headers = completed.Headers;
         if (headers.TryGetValue(Headers.TimeSent, out var timeSentString))
         {
             timeSent = DateTimeOffsetHelper.ToDateTimeOffset(timeSentString);
@@ -17,9 +17,9 @@ static class Extensions
         return false;
     }
 
-    public static bool TryGetMessageType(this ReceivePipelineCompleted completed, out string processedMessageType)
+    public static bool TryGetMessageType(this ReceiveCompleted completed, out string processedMessageType)
     {
-        return completed.ProcessedMessage.Headers.TryGetMessageType(out processedMessageType);
+        return completed.Headers.TryGetMessageType(out processedMessageType);
     }
 
     internal static bool TryGetMessageType(this IReadOnlyDictionary<string, string> headers, out string processedMessageType)

--- a/src/NServiceBus.Metrics/MetricsFeature.cs
+++ b/src/NServiceBus.Metrics/MetricsFeature.cs
@@ -44,8 +44,8 @@
             var signalBuilders = new SignalProbeBuilder[]
             {
             new MessagePulledFromQueueProbeBuilder(performanceDiagnosticsBehavior),
-            new MessageProcessingFailureProbeBuilder(performanceDiagnosticsBehavior),
-            new MessageProcessingSuccessProbeBuilder(performanceDiagnosticsBehavior),
+            new MessageProcessingFailureProbeBuilder(context),
+            new MessageProcessingSuccessProbeBuilder(context),
             new RetriesProbeBuilder(options)
             };
 

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.852" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-PullRequest5936.873" />
     <PackageReference Include="Particular.Packaging" Version="1.0.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-PullRequest5936.873" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-Alpha.866" />
     <PackageReference Include="Particular.Packaging" Version="1.0.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
@@ -14,8 +14,13 @@ class CriticalTimeProbeBuilder : DurationProbeBuilder
 
     protected override void WireUp(DurationProbe probe)
     {
-        context.Pipeline.OnReceivePipelineCompleted((e, _) =>
+        context.OnReceiveCompleted((e, _) =>
         {
+            if (!e.WasAcknowledged || e.OnMessageFailed)
+            {
+                return TaskExtensions.Completed;
+            }
+
             if (e.TryGetTimeSent(out var timeSent))
             {
                 var endToEndTime = e.CompletedAt - timeSent;

--- a/src/NServiceBus.Metrics/ProbeBuilders/MessageProcessingSuccessProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/MessageProcessingSuccessProbeBuilder.cs
@@ -1,15 +1,31 @@
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Features;
+
 [ProbeProperties("# of msgs successfully processed / sec", "The current number of messages processed successfully by the transport per second.")]
 class MessageProcessingSuccessProbeBuilder : SignalProbeBuilder
 {
-    public MessageProcessingSuccessProbeBuilder(ReceivePerformanceDiagnosticsBehavior behavior)
+    public MessageProcessingSuccessProbeBuilder(FeatureConfigurationContext context)
     {
-        this.behavior = behavior;
+        this.context = context;
     }
 
     protected override void WireUp(SignalProbe probe)
     {
-        behavior.ProcessingSuccess = probe;
+        context.OnReceiveCompleted((e, _) =>
+        {
+            if (!e.OnMessageFailed && e.WasAcknowledged)
+            {
+                e.TryGetMessageType(out var messageType);
+
+                var @event = new SignalEvent(messageType);
+
+                probe.Signal(ref @event);
+            }
+
+            return Task.CompletedTask;
+        });
     }
 
-    readonly ReceivePerformanceDiagnosticsBehavior behavior;
+    readonly FeatureConfigurationContext context;
 }

--- a/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ProcessingTimeProbeBuilder.cs
@@ -12,8 +12,13 @@ class ProcessingTimeProbeBuilder : DurationProbeBuilder
 
     protected override void WireUp(DurationProbe probe)
     {
-        context.Pipeline.OnReceivePipelineCompleted((e, _) =>
+        context.OnReceiveCompleted((e, _) =>
         {
+            if (!e.WasAcknowledged || e.OnMessageFailed)
+            {
+                return TaskExtensions.Completed;
+            }
+
             e.TryGetMessageType(out var messageTypeProcessed);
 
             var processingTime = e.CompletedAt - e.StartedAt;

--- a/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/ReceivePerformanceDiagnosticsBehavior.cs
@@ -5,7 +5,7 @@ using NServiceBus.Pipeline;
 
 class ReceivePerformanceDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
 {
-    public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+    public Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
     {
         context.MessageHeaders.TryGetMessageType(out var messageType);
 
@@ -13,20 +13,8 @@ class ReceivePerformanceDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessage
 
         MessagePulledFromQueue?.Signal(ref @event);
 
-        try
-        {
-            await next(context).ConfigureAwait(false);
-        }
-        catch (Exception)
-        {
-            ProcessingFailure?.Signal(ref @event);
-            throw;
-        }
-
-        ProcessingSuccess?.Signal(ref @event);
+        return next(context);
     }
 
     public SignalProbe MessagePulledFromQueue;
-    public SignalProbe ProcessingFailure;
-    public SignalProbe ProcessingSuccess;
 }


### PR DESCRIPTION
Closes https://github.com/Particular/NServiceBus.Metrics/issues/174