### PR TITLE
Critical time calculated using DeliverAt header - Release 3.1

### DIFF
--- a/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
+++ b/src/NServiceBus.Metrics.Tests/NServiceBus.Metrics.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NServiceBus" Version="7.2.3" />
+    <PackageReference Include="NServiceBus" Version="7.7.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" />

--- a/src/NServiceBus.Metrics/Extensions.cs
+++ b/src/NServiceBus.Metrics/Extensions.cs
@@ -17,6 +17,18 @@ static class Extensions
         return false;
     }
 
+    public static bool TryGetDeliverAt(this ReceivePipelineCompleted completed, out DateTime deliverAt)
+    {
+        var headers = completed.ProcessedMessage.Headers;
+        if (headers.TryGetValue(Headers.DeliverAt, out var deliverAtString))
+        {
+            deliverAt = DateTimeExtensions.ToUtcDateTime(deliverAtString);
+            return true;
+        }
+        deliverAt = DateTime.MinValue;
+        return false;
+    }
+
     public static bool TryGetMessageType(this ReceivePipelineCompleted completed, out string processedMessageType)
     {
         return completed.ProcessedMessage.Headers.TryGetMessageType(out processedMessageType);

--- a/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
+++ b/src/NServiceBus.Metrics/NServiceBus.Metrics.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.7.0, 8.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.2.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/CriticalTimeProbeBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using NServiceBus;
 using NServiceBus.Features;
 using NServiceBus.Metrics;
@@ -16,9 +17,9 @@ class CriticalTimeProbeBuilder : DurationProbeBuilder
     {
         context.Pipeline.OnReceivePipelineCompleted(e =>
         {
-            if (e.TryGetTimeSent(out var timeSent))
+            if (e.TryGetDeliverAt(out var startTime) || e.TryGetTimeSent(out startTime))
             {
-                var endToEndTime = e.CompletedAt - timeSent;
+                var endToEndTime = e.CompletedAt - startTime;
                 e.TryGetMessageType(out var messageType);
 
                 var @event = new DurationEvent(endToEndTime, messageType);

--- a/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
+++ b/src/NServiceBus.Metrics/ProbeBuilders/RetriesProbeBuilder.cs
@@ -16,8 +16,10 @@
         protected override void WireUp(SignalProbe probe)
         {
             var errors = notifications.Errors;
+#pragma warning disable CS0618 // Type or member is obsolete
             errors.MessageHasFailedAnImmediateRetryAttempt += (sender, message) => Signal(message.Headers, probe);
             errors.MessageHasBeenSentToDelayedRetries += (sender, message) => Signal(message.Headers, probe);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         static void Signal(Dictionary<string, string> messageHeaders, SignalProbe probe)


### PR DESCRIPTION
When delay delivery is set for a message, calculate the critical time using the `DeliverAt` header from the message instead of the `TimeSent` header to account for the delayed delivery.