### PR TITLE
Fix obsolete message

### DIFF
--- a/src/NServiceBus.Metrics.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Metrics.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -24,9 +24,8 @@ namespace NServiceBus
     public static class MetricsConfigurationExtensions
     {
         public static NServiceBus.MetricsOptions EnableMetrics(this NServiceBus.EndpointConfiguration endpointConfiguration) { }
-        [System.Obsolete("Use `EnableOptions(this EndpointConfiguration endpointConfiguration)` instead. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "5.0.0.", true)]
+        [System.Obsolete("Use `EndpointConfiguration.EnableMetrics()` instead. The member currently throws " +
+            "a NotImplementedException. Will be removed in version 5.0.0.", true)]
         public static NServiceBus.MetricsOptions EnableMetrics(this NServiceBus.Settings.SettingsHolder settings) { }
     }
     public class MetricsOptions

--- a/src/NServiceBus.Metrics/obsoletes-v4.cs
+++ b/src/NServiceBus.Metrics/obsoletes-v4.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
     public static partial class MetricsConfigurationExtensions
     {
         [ObsoleteEx(
-            ReplacementTypeOrMember = "EnableOptions(this EndpointConfiguration endpointConfiguration)",
+            ReplacementTypeOrMember = "EndpointConfiguration.EnableMetrics()",
             TreatAsErrorFromVersion = "4",
             RemoveInVersion = "5"
             )]


### PR DESCRIPTION
The current obsolete message states to use the `EnableOptions` API instead of `settings.EnableMetrics()` buch such an API doesn't exist. I assume this should be referring to the `EnableMetrics` API on the endpoint config instead.

I'm not sure about the exact definition of the replacement type, but I think the way proposed in this PR is more helpful and clearer to use for users.