### PR TITLE
Use C# 12 collection expressions

### DIFF
--- a/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -11,7 +11,7 @@
     {
         public DefaultServer()
         {
-            typesToInclude = new List<Type>();
+            typesToInclude = [];
         }
 
         public DefaultServer(List<Type> typesToInclude)

--- a/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_having_metrics_handlers_registered.cs
+++ b/src/NServiceBus.Metrics.AcceptanceTests/Tests/When_having_metrics_handlers_registered.cs
@@ -29,10 +29,10 @@ public class When_having_metrics_handlers_registered : NServiceBusAcceptanceTest
             .Select(t => t.GetCustomAttribute<ProbePropertiesAttribute>().Name)
             .ToArray();
 
-        errorProbes = new HashSet<string>
-        {
+        errorProbes =
+        [
             "# of msgs pulled from the input queue /sec" // added explicitly as the message is pulled from the queue even in an error scenario
-        };
+        ];
 
         foreach (var name in probesNames)
         {


### PR DESCRIPTION
This change satisfies the new `IDE0028` analyzer rules in the .NET 8 SDK.